### PR TITLE
[ci] Use the latest version of `JamesIves/github-pages-deploy-action`

### DIFF
--- a/.github/workflows/siteupdate.yml
+++ b/.github/workflows/siteupdate.yml
@@ -53,7 +53,7 @@ jobs:
           echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; URL=latest/manual/intro" /></head><body></body></html>' > $HOW_OUT/index.html
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.0.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: _doc # The folder the action should deploy.


### PR DESCRIPTION
To fix the following warnings:
https://github.com/ocsigen/tuto/actions/runs/6982254968.
