### PR TITLE
Fix collision of "i" at example in basics-server.wiki

### DIFF
--- a/tutos/7.1/manual/basics-server.wiki
+++ b/tutos/7.1/manual/basics-server.wiki
@@ -299,10 +299,10 @@ Then register an OCaml function as handler on this service:
 <<code language="ocaml" class="server"|
 let () =
   Eliom_registration.Html.register ~service:myservice
-    (fun (s, i) () ->
+    (fun (s, num) () ->
       Lwt.return
          Eliom_content.Html.F.(html (head (title (txt "")) [])
-                                    (body [h1 [txt (s^string_of_int i)]])))
+                                    (body [h1 [txt (s^string_of_int num)]])))
 >>
 
 The handler takes as first parameter the GET page parameters, typed according to


### PR DESCRIPTION
I found that following example in "Eliom: Typing page parameters" doesn't work.

```ocaml
let () =
  Eliom_registration.Html.register ~service:myservice
    (fun (s, i) () ->
      Lwt.return
         Eliom_content.Html.F.(html (head (title (txt "")) [])
                                    (body [h1 [txt (s^string_of_int i)]])))
```

In definition of html, symbol `i` is used for parameter, but this collide to element for list item. So I replaced symbol `i` to `num`, as following.

```ocaml
let () =
  Eliom_registration.Html.register ~service:myservice
    (fun (s, num) () ->
      Lwt.return
         Eliom_content.Html.F.(html (head (title (txt "")) [])
                                    (body [h1 [txt (s^string_of_int num)]])))
```