### PR TITLE
doc: use page references for internal manual links (not .html URLs)

### DIFF
--- a/tutos/8.0/manual/application.mld
+++ b/tutos/8.0/manual/application.mld
@@ -1013,7 +1013,7 @@ You can then test your application ([make test.byte]).
   from server side, through module Eliom_shared.
 
   This basic program does not show the full power of reactive
-  programming, however. See {{:tutoreact.html}this tutorial}
+  programming, however. See {{!page-tutoreact}this tutorial}
   for a better introduction to reactive programming with Eliom.
 
 {%wodoc:end%}
@@ -1169,4 +1169,4 @@ The first version of the program is now complete.
 
 If you want to continue learning client-server programming with Eliom
 and build your first application, we suggest to read
-{{:start.html}the tutorial about Ocsigen Start}.
+{{!page-start}the tutorial about Ocsigen Start}.

--- a/tutos/8.0/manual/basics-server.mld
+++ b/tutos/8.0/manual/basics-server.mld
@@ -14,7 +14,7 @@ sessions or continuation-based Web programming.
 Programming with Eliom will make your website ready for future
 evolutions by allowing you to introduce progressively client-side
 features like event handlers, fully in OCaml. You will even be able to
-turn your website into a {{:basics.html}distributed client-server Web app},
+turn your website into a {{!page-basics}distributed client-server Web app},
 and even a mobile app if needed in the future, without having to rewrite
 anything.
 
@@ -62,7 +62,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{:lwt.html}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -343,7 +343,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{:html.html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -542,7 +542,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom_service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os_lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{:interaction.html}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
+{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img

--- a/tutos/8.0/manual/basics.mld
+++ b/tutos/8.0/manual/basics.mld
@@ -7,12 +7,12 @@ with Ocsigen. Use it as your training plan or as a cheat sheet while programming
 
 Depending on your needs, you may not need to learn all this. Ocsigen is
 very flexible and can be used both for Web site programming (see
-{{:basics-server.html}this page}) or more complex client-server Web apps and
+{{!page-basics-server}this page}) or more complex client-server Web apps and
 their mobile counterparts.
 
 In parallel to the reading of that page,
 we recommend to generate your first {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start} app to see
-running examples of all these concepts (see {{:start.html}that page}).
+running examples of all these concepts (see {{!page-start}that page}).
 
 {%wodoc:div class="quickstart-block"%}
 {b Too long; didn't read? Get your first app running in 3 minutes:}
@@ -25,7 +25,7 @@ make test.byte
 v}
 Then open [http://localhost:8080]. {%html:<br/>%}
 Requires [postgresql] and [sass] (or [sassc]).
-Read the {{:start.html}detailed instructions} if needed.
+Read the {{!page-start}detailed instructions} if needed.
 {%wodoc:end%}
 
 
@@ -72,7 +72,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{:lwt.html}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -200,7 +200,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{:html.html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -341,7 +341,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom_service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os_lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{:interaction.html}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
+{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img
@@ -493,7 +493,7 @@ define a typed interface
 for form elements. Use this for links (see above), or if you program traditional
 server-side Web interaction (with or without client-side program). This will statically check that your forms
 match the services. See more information in the
-{{:basics-server.html}server-side programming manual}.
+{{!page-basics-server}server-side programming manual}.
 
 {%wodoc:end%}
 {%wodoc:section class="docblock"%}
@@ -704,7 +704,7 @@ If such section is reached during module initialization on the server
 (global client section), it will be executed on client side everytime
 a new client side program is launched.
 
-The tutorial {{:tutowidgets.html}Client-Server Widgets}
+The tutorial {{!page-tutowidgets}Client-Server Widgets}
 shows how client values can be manipulated
 on server side.
 
@@ -844,8 +844,8 @@ page generation on both sides.
 - Examples of client sections, injections or server functions can be found in
 the demo included in
 {{:https://github.com/ocsigen/ocsigen-start/blob/master/template.distillery/demo_rpc.eliom}Ocsigen-Start's app template}.
-- {{:application.html}This page} is a step by step introduction to client-server programming with Eliom for beginners.
-- {{:tutowidgets.html}This one} is a quick introduction for more experienced OCaml developers.
+- {{!page-application}This page} is a step by step introduction to client-server programming with Eliom for beginners.
+- {{!page-tutowidgets}This one} is a quick introduction for more experienced OCaml developers.
 - Comprehensive documentation on client-server programming can be found in
 {{:https://ocsigen.org/eliom/latest/}Eliom's user manual}.
 {%wodoc:end%}
@@ -1032,7 +1032,7 @@ user registration, login box, notification system, etc.
 
 It also provides a demo of many features presented in this page.
 A {{:https://ocsigen.org/ocsigen-start/latest/demo/}live version} is accessible online.
-Read {{:start.html}this page} to create your first Ocsigen Start
+Read {{!page-start}this page} to create your first Ocsigen Start
 app and take time to study the code of each example.
 
 User management features are fully usable in production and
@@ -1104,7 +1104,7 @@ Have a look at a {{:https://ocsigen-1.inria.fr/ocsigen-start/demo/demo-notif}run
 Eliom has other communication modules:
 - {!Eliom_bus} defines a communication bus,
 that you can use to share information with other client processes
-(see an example {{:application.html}here}).
+(see an example {{!page-application}here}).
 - {!Eliom_react} defines client-server React events.
 - {!Eliom_comet} is lower level interface for
 server to client communication.
@@ -1215,7 +1215,7 @@ take a parameter of type
 This enables incremental update of the content
 (usually, appending an element at the end of the list,
 without having to redraw the whole list).
-See an example with [ReactiveData] in {{:tutoreact.html}this tutorial}.
+See an example with [ReactiveData] in {{!page-tutoreact}this tutorial}.
 
 Node attributes can also be reactive. For example if [s] has type [string list React.S.t],
 you can write [Eliom_content.Html.F.div ~a:[R.a_class s] []].

--- a/tutos/8.0/manual/custom-conf.mld
+++ b/tutos/8.0/manual/custom-conf.mld
@@ -6,7 +6,7 @@ Custom configuration options{%wodoc:end%}
 It is not convenient to have to edit the code to change some
 configurations, like the location where are saved the favorite
 images in the Graffiti tutorial
-(see: {{:pictures.html}Saving favorite pictures}).
+(see: {{!page-pictures}Saving favorite pictures}).
 Fortunately Ocsigen provides a mechanism to extend its
 configuration file.
 

--- a/tutos/8.0/manual/how-does-a-page-s-source-code-look.mld
+++ b/tutos/8.0/manual/how-does-a-page-s-source-code-look.mld
@@ -3,7 +3,7 @@
 {2 Eliom client-server applications}
 
 Eliom client-server applications are running in your browser for a {{:https://ocsigen.org/eliom/latest/clientserver-applications.html}certain lifetime} and consist of one or several pages/URLs.
-An application has its associated js file, which must have the same name ({{:how-to-compile-my-ocsigen-pages.html}generated automatically by the default makefile} and added automatically by Eliom in the page).
+An application has its associated js file, which must have the same name ({{!page-how-to-compile-my-ocsigen-pages}generated automatically by the default makefile} and added automatically by Eliom in the page).
 
 For example, we define an application called {e example}:
 {@ocaml[
@@ -31,7 +31,7 @@ The path is a list of string corresponding to the url. Here, the list is empty b
 If, for example, the list is ["hello";"world"], the page will be accessed using the address:
 {[http://website.com/hello/world/]}
 
-More information about parameters: {{:how-to-use-get-parameters-or-parameters-in-the-url.html}How to use GET parameters (parameters in the URL)?}
+More information about parameters: {{!page-how-to-use-get-parameters-or-parameters-in-the-url}How to use GET parameters (parameters in the URL)?}
 
 Now that our service has been declared, we associate to it an OCaml function that will generate the page. We call this {e service registration}. If the service belongs to the application, we use the registrations functions from module [Example] defined above.
 

--- a/tutos/8.0/manual/how-to-add-a-div.mld
+++ b/tutos/8.0/manual/how-to-add-a-div.mld
@@ -8,7 +8,7 @@ div ~a:[a_class ["firstclass"; "secondclass"]] [txt "Hello!"]
 (Details of available elements in type
 {!Html_types.flow5}).
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/8.0/manual/how-to-add-a-list.mld
+++ b/tutos/8.0/manual/how-to-add-a-list.mld
@@ -23,7 +23,7 @@
 
 {b Required parameter}: list containing {b li} elements ({{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-li_attrib}Details of li content}).
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {3 Definition list}
 
@@ -53,7 +53,7 @@ Details:
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-phrasing}dd content}
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-flow5}dt content}
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/8.0/manual/how-to-add-a-select-or-other-form-element.mld
+++ b/tutos/8.0/manual/how-to-add-a-select-or-other-form-element.mld
@@ -35,7 +35,7 @@ Raw.select [option (txt "hello");
 
 {2 Links}
 
-- {{:how-to-write-forms.html}How to write forms}
+- {{!page-how-to-write-forms}How to write forms}
 - {{:https://ocsigen.org/eliom/latest/server-links.html}Eliom forms and links}
 - API
   {!Eliom_content.Html.D.Form}

--- a/tutos/8.0/manual/how-to-implement-a-notification-system.mld
+++ b/tutos/8.0/manual/how-to-implement-a-notification-system.mld
@@ -31,7 +31,7 @@ This make possible to customize the notifications.
 Return [None] if you don't want him to be notified.
 
 For more information, have a look at
-{{:tutoreact.html}the tutorial
+{{!page-tutoreact}the tutorial
 about client-server reactive applications}.
 
 
@@ -72,9 +72,9 @@ And call function [notify] on the channel (from server side)
 when you want to notify the client.
 
 To get back the [notify] functions for one user, you may want to
-{{:how-to-iterate-on-all-sessions-for-one-user-or-all-tabs.html}iterate on all client process states}.
+{{!page-how-to-iterate-on-all-sessions-for-one-user-or-all-tabs}iterate on all client process states}.
 To do that, create a session group for each user
-(see {{:how-to-register-session-data.html}How to register session data}).
+(see {{!page-how-to-register-session-data}How to register session data}).
 Here we suppose that the session group name is the user_id, as a string.
 Then iterate on all sessions from this group, and on all client processes
 for each session.

--- a/tutos/8.0/manual/how-to-make-hello-world-in-ocsigen.mld
+++ b/tutos/8.0/manual/how-to-make-hello-world-in-ocsigen.mld
@@ -37,13 +37,13 @@ let _ =
 {2 }
 
 - To {e understand} this code, have a look at
-{{:how-does-a-page-s-source-code-look.html}How does a page's source code look?}
+{{!page-how-does-a-page-s-source-code-look}How does a page's source code look?}
 - Or directly continue by compiling this code:
-{{:how-to-compile-my-ocsigen-pages.html}How to compile my Ocsigen pages?}
+{{!page-how-to-compile-my-ocsigen-pages}How to compile my Ocsigen pages?}
 
 
 
 {2 Links}
 
-- {{:application.html}Tutorial to write a client/server application}
-- {{:interaction.html}Tutorial to write a server side web site}
+- {{!page-application}Tutorial to write a client/server application}
+- {{!page-interaction}Tutorial to write a server side web site}

--- a/tutos/8.0/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
+++ b/tutos/8.0/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
@@ -36,7 +36,7 @@ The style attribute specifies an inline style for an element. The style attribut
 
 Using this attribute to stylish elements is not a good practice.
 You should rather use
-{{:how-to-add-css-stylesheet.html}an external CSS file}.
+{{!page-how-to-add-css-stylesheet}an external CSS file}.
 
 Its parameter is a string.
 {@ocaml[~a:[a_style "color: pink; padding: 10px;"]]}

--- a/tutos/8.0/manual/how-to-write-forms.mld
+++ b/tutos/8.0/manual/how-to-write-forms.mld
@@ -107,4 +107,4 @@ using standard tyxml constructors.
 Use module {{:https://ocsigen.org/eliom/latest/eliom.server/Eliom/Content/Html/D/Raw/index.html}Eliom_content.Html.D.Raw}.
 
 {2 Links}
-- {{:how-to-add-a-select-or-other-form-element.html}How to write a select (or other form element)?}
+- {{!page-how-to-add-a-select-or-other-form-element}How to write a select (or other form element)?}

--- a/tutos/8.0/manual/how-to-write-titles-and-paragraphs.mld
+++ b/tutos/8.0/manual/how-to-write-titles-and-paragraphs.mld
@@ -16,7 +16,7 @@ p [txt "Some text, blah blah blah"]
 
 {b Required parameter}: list containing other elements (content: {!Html_types.flow5} elements).
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/8.0/manual/interaction.mld
+++ b/tutos/8.0/manual/interaction.mld
@@ -7,7 +7,7 @@
 This chapter of the tutorial explains how to create a small web site
 with several pages, users, sessions, and other elements of classical
 web development.  Then, in
-{{:misc.html}another tutorial}, we will incorporate the
+{{!page-misc}another tutorial}, we will incorporate the
 features of this site into our Graffiti application, to
 demonstrate that we can combine this kind of interaction with client-side
 programs.
@@ -368,7 +368,7 @@ and POST parameters. In that case, GET parameters will be in the URL
 and POST parameters will probably come from a form. In HTML, it is not
 possible to mix GET and POST parameters in the same form.
 
-See also {{:basics.html}the cheat-sheet} for an
+See also {{!page-basics}the cheat-sheet} for an
 comprehensive overview on the different types of services.
 
 {%wodoc:end%}
@@ -1257,5 +1257,5 @@ let () = Eliom_content.Html.D.(
 )
 ]}
 
-{{:application.html}prev}
-{{:misc.html}next}
+{{!page-application}prev}
+{{!page-misc}next}

--- a/tutos/8.0/manual/intro.mld
+++ b/tutos/8.0/manual/intro.mld
@@ -53,24 +53,24 @@ new programming techniques to become autonomous.
 Depending on your level and goals, we suggest to continue by reading
 some of the following chapters:
 
-- Chapter {{:basics.html}Client-server application programming guide} can be used as your training plan.
+- Chapter {{!page-basics}Client-server application programming guide} can be used as your training plan.
 It provides a wide overview of each main concept, with links to more detailed
 documentation.
-- If you want to start with a server-side only Web site, read {{:basics-server.html}Server-side website programming guide} instead.
+- If you want to start with a server-side only Web site, read {{!page-basics-server}Server-side website programming guide} instead.
 - Then, a good starting point is this
-{{:start.html}Ocsigen Start tutorial},
+{{!page-start}Ocsigen Start tutorial},
 if you plan to build a client-server Web (and/or mobile) app.
 It will help you to build your first app very quickly,
 with many code samples to study.
 - If you are fluent in OCaml and want a quick introduction to
 client-server Web programming with Eliom,
 read tutorial
-{{:tutowidgets.html}Eliom apps basics: writing client server widgets}.
+{{!page-tutowidgets}Eliom apps basics: writing client server widgets}.
 It illusrates the client-server syntax with an example,
 and is a good starting point for understanding Eliom's client-server features.
 - If you want a full step-by-step tutorial on how to write a client-server Web
 application, read tutorial
-{{:application.html}Client-server application}.
+{{!page-application}Client-server application}.
 It describes step by step how to write a client/server
 {{:https://ocsigen.org/graffiti/}collaborative drawing application}. You will learn,
 from the very beginning, how to:
@@ -82,10 +82,10 @@ from the very beginning, how to:
 - {e Communicate} with the server, in both directions
 - Create services with {e non-HTML output}
 - If you want to build mobile applications,
-read tutorial {{:mobile.html}Mobile applications with Ocsigen}.
+read tutorial {{!page-mobile}Mobile applications with Ocsigen}.
 It describes how to build a mobile app (e.g., for Android)
 with the same codebase as for your Web application.
-- If you want to write a more traditional Web site, with pages, forms, and sessions, read tutorial {{:interaction.html}Service based Web programming}.
+- If you want to write a more traditional Web site, with pages, forms, and sessions, read tutorial {{!page-interaction}Service based Web programming}.
 It is devoted to server side programming.
 It shows how to
 create a new Web site with several pages and user connections.
@@ -96,7 +96,7 @@ You will learn how to:
 - Create services performing {e actions} (with no output)
 - Dynamically register new services ({e continuation based} Web programming)
 - If you want to learn more details about Ocsigen
-read tutorial {{:misc.html}Miscellaneous features}.
+read tutorial {{!page-misc}Miscellaneous features}.
 It will mix the client-server drawing application
 with the session mechanism and user management
 to produce a multi-user collaborative drawing
@@ -133,7 +133,7 @@ their {{:http://webchat.freenode.net/?channels=ocsigen}webchat})!
 
 
 Now, we recommend to read, chapter
-{{:basics.html}All Ocsigen in one page}
+{{!page-basics}All Ocsigen in one page}
 for a wide and complete overview.
 
 

--- a/tutos/8.0/manual/misc.mld
+++ b/tutos/8.0/manual/misc.mld
@@ -521,4 +521,4 @@ to [disconnect_box]
        canvas;])
 ]}
 
-{{:interaction.html}prev}
+{{!page-interaction}prev}

--- a/tutos/8.0/manual/reactivemediaplayer.mld
+++ b/tutos/8.0/manual/reactivemediaplayer.mld
@@ -1,6 +1,6 @@
 {0 Reactive Media Player}
 
-You should read the {{:music.html}Playing Music} tutorial before this one.
+You should read the {{!page-music}Playing Music} tutorial before this one.
 
 Since version 4, Eliom embeds the
 {{:http://erratique.ch/logiciel/react}React} library in order to
@@ -82,7 +82,7 @@ optional parameters of React.S functions producing a signal (like
 
 
 This part explains how to create a simple media player, similar to the
-{{:music.html}Playing Music} tutorial but with custom
+{{!page-music}Playing Music} tutorial but with custom
 controls.We will apply
 {{:https://en.wikipedia.org/wiki/Functional_reactive_programming}FRP (Functional Reactive Programming)}.
 

--- a/tutos/8.0/manual/tutowidgets.mld
+++ b/tutos/8.0/manual/tutowidgets.mld
@@ -7,7 +7,7 @@ It is probably a good starting point if you know OCaml well, and want
 to quickly learn how to write a client-server Eliom application with a
 short example and concise explanations.  For more detailed explanations, see
 the
-{{:application.html}"graffiti" tutorial},
+{{!page-application}"graffiti" tutorial},
 or read the manuals.
 
 The goal is to show that, unlike many JavaScript libraries that build
@@ -394,7 +394,7 @@ let%server _ = Eliom_content.Html.D.(
 An important feature missing from this tutorial is the ability
 to call server functions from the client-side program ("server functions").
 You can find a quick description of this
-in {{:how-to-call-a-server-side-function-from-client-side.html}this mini HOWTO} or
+in {{!page-how-to-call-a-server-side-function-from-client-side}this mini HOWTO} or
 in {{:https://ocsigen.org/eliom/latest/clientserver-communication.html#rpc}Eliom's manual}.
 
 {2 Services}

--- a/tutos/dev/manual/application.mld
+++ b/tutos/dev/manual/application.mld
@@ -1013,7 +1013,7 @@ You can then test your application ([make test.byte]).
   from server side, through module Eliom.Shared.
 
   This basic program does not show the full power of reactive
-  programming, however. See {{:tutoreact.html}this tutorial}
+  programming, however. See {{!page-tutoreact}this tutorial}
   for a better introduction to reactive programming with Eliom.
 
 {%wodoc:end%}
@@ -1169,4 +1169,4 @@ The first version of the program is now complete.
 
 If you want to continue learning client-server programming with Eliom
 and build your first application, we suggest to read
-{{:start.html}the tutorial about Ocsigen Start}.
+{{!page-start}the tutorial about Ocsigen Start}.

--- a/tutos/dev/manual/basics-server.mld
+++ b/tutos/dev/manual/basics-server.mld
@@ -14,7 +14,7 @@ sessions or continuation-based Web programming.
 Programming with Eliom will make your website ready for future
 evolutions by allowing you to introduce progressively client-side
 features like event handlers, fully in OCaml. You will even be able to
-turn your website into a {{:basics.html}distributed client-server Web app},
+turn your website into a {{!page-basics}distributed client-server Web app},
 and even a mobile app if needed in the future, without having to rewrite
 anything.
 
@@ -62,7 +62,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{:lwt.html}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -343,7 +343,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{:html.html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -542,7 +542,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom.Service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os.Lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{:interaction.html}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
+{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img

--- a/tutos/dev/manual/basics.mld
+++ b/tutos/dev/manual/basics.mld
@@ -7,12 +7,12 @@ with Ocsigen. Use it as your training plan or as a cheat sheet while programming
 
 Depending on your needs, you may not need to learn all this. Ocsigen is
 very flexible and can be used both for Web site programming (see
-{{:basics-server.html}this page}) or more complex client-server Web apps and
+{{!page-basics-server}this page}) or more complex client-server Web apps and
 their mobile counterparts.
 
 In parallel to the reading of that page,
 we recommend to generate your first {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start} app to see
-running examples of all these concepts (see {{:start.html}that page}).
+running examples of all these concepts (see {{!page-start}that page}).
 
 {%wodoc:div class="quickstart-block"%}
 {b Too long; didn't read? Get your first app running in 3 minutes:}
@@ -25,7 +25,7 @@ make test.byte
 v}
 Then open [http://localhost:8080]. {%html:<br/>%}
 Requires [postgresql] and [sass] (or [sassc]).
-Read the {{:start.html}detailed instructions} if needed.
+Read the {{!page-start}detailed instructions} if needed.
 {%wodoc:end%}
 
 
@@ -72,7 +72,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{:lwt.html}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -200,7 +200,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{:html.html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
 
 {%wodoc:end%}
 
@@ -341,7 +341,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom.Service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os.Lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{:interaction.html}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
+{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img
@@ -493,7 +493,7 @@ define a typed interface
 for form elements. Use this for links (see above), or if you program traditional
 server-side Web interaction (with or without client-side program). This will statically check that your forms
 match the services. See more information in the
-{{:basics-server.html}server-side programming manual}.
+{{!page-basics-server}server-side programming manual}.
 
 {%wodoc:end%}
 {%wodoc:section class="docblock"%}
@@ -704,7 +704,7 @@ If such section is reached during module initialization on the server
 (global client section), it will be executed on client side everytime
 a new client side program is launched.
 
-The tutorial {{:tutowidgets.html}Client-Server Widgets}
+The tutorial {{!page-tutowidgets}Client-Server Widgets}
 shows how client values can be manipulated
 on server side.
 
@@ -844,8 +844,8 @@ page generation on both sides.
 - Examples of client sections, injections or server functions can be found in
 the demo included in
 {{:https://github.com/ocsigen/ocsigen-start/blob/master/template.distillery/demo_rpc.eliom}Ocsigen-Start's app template}.
-- {{:application.html}This page} is a step by step introduction to client-server programming with Eliom for beginners.
-- {{:tutowidgets.html}This one} is a quick introduction for more experienced OCaml developers.
+- {{!page-application}This page} is a step by step introduction to client-server programming with Eliom for beginners.
+- {{!page-tutowidgets}This one} is a quick introduction for more experienced OCaml developers.
 - Comprehensive documentation on client-server programming can be found in
 {{:https://ocsigen.org/eliom/latest/}Eliom's user manual}.
 {%wodoc:end%}
@@ -1032,7 +1032,7 @@ user registration, login box, notification system, etc.
 
 It also provides a demo of many features presented in this page.
 A {{:https://ocsigen.org/ocsigen-start/latest/demo/}live version} is accessible online.
-Read {{:start.html}this page} to create your first Ocsigen Start
+Read {{!page-start}this page} to create your first Ocsigen Start
 app and take time to study the code of each example.
 
 User management features are fully usable in production and
@@ -1104,7 +1104,7 @@ Have a look at a {{:https://ocsigen-1.inria.fr/ocsigen-start/demo/demo-notif}run
 Eliom has other communication modules:
 - {!Eliom.Bus} defines a communication bus,
 that you can use to share information with other client processes
-(see an example {{:application.html}here}).
+(see an example {{!page-application}here}).
 - {!Eliom_react} defines client-server React events.
 - {!Eliom.Comet} is lower level interface for
 server to client communication.
@@ -1215,7 +1215,7 @@ take a parameter of type
 This enables incremental update of the content
 (usually, appending an element at the end of the list,
 without having to redraw the whole list).
-See an example with [ReactiveData] in {{:tutoreact.html}this tutorial}.
+See an example with [ReactiveData] in {{!page-tutoreact}this tutorial}.
 
 Node attributes can also be reactive. For example if [s] has type [string list React.S.t],
 you can write [Eliom.Content.Html.F.div ~a:[R.a_class s] []].

--- a/tutos/dev/manual/custom-conf.mld
+++ b/tutos/dev/manual/custom-conf.mld
@@ -6,7 +6,7 @@ Custom configuration options{%wodoc:end%}
 It is not convenient to have to edit the code to change some
 configurations, like the location where are saved the favorite
 images in the Graffiti tutorial
-(see: {{:pictures.html}Saving favorite pictures}).
+(see: {{!page-pictures}Saving favorite pictures}).
 Fortunately Ocsigen provides a mechanism to extend its
 configuration file.
 

--- a/tutos/dev/manual/how-does-a-page-s-source-code-look.mld
+++ b/tutos/dev/manual/how-does-a-page-s-source-code-look.mld
@@ -3,7 +3,7 @@
 {2 Eliom client-server applications}
 
 Eliom client-server applications are running in your browser for a {{:https://ocsigen.org/eliom/latest/clientserver-applications.html}certain lifetime} and consist of one or several pages/URLs.
-An application has its associated js file, which must have the same name ({{:how-to-compile-my-ocsigen-pages.html}generated automatically by the default makefile} and added automatically by Eliom in the page).
+An application has its associated js file, which must have the same name ({{!page-how-to-compile-my-ocsigen-pages}generated automatically by the default makefile} and added automatically by Eliom in the page).
 
 For example, we define an application called {e example}:
 {@ocaml[
@@ -31,7 +31,7 @@ The path is a list of string corresponding to the url. Here, the list is empty b
 If, for example, the list is ["hello";"world"], the page will be accessed using the address:
 {[http://website.com/hello/world/]}
 
-More information about parameters: {{:how-to-use-get-parameters-or-parameters-in-the-url.html}How to use GET parameters (parameters in the URL)?}
+More information about parameters: {{!page-how-to-use-get-parameters-or-parameters-in-the-url}How to use GET parameters (parameters in the URL)?}
 
 Now that our service has been declared, we associate to it an OCaml function that will generate the page. We call this {e service registration}. If the service belongs to the application, we use the registrations functions from module [Example] defined above.
 

--- a/tutos/dev/manual/how-to-add-a-div.mld
+++ b/tutos/dev/manual/how-to-add-a-div.mld
@@ -8,7 +8,7 @@ div ~a:[a_class ["firstclass"; "secondclass"]] [txt "Hello!"]
 (Details of available elements in type
 {!Html_types.flow5}).
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/dev/manual/how-to-add-a-list.mld
+++ b/tutos/dev/manual/how-to-add-a-list.mld
@@ -23,7 +23,7 @@
 
 {b Required parameter}: list containing {b li} elements ({{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-li_attrib}Details of li content}).
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {3 Definition list}
 
@@ -53,7 +53,7 @@ Details:
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-phrasing}dd content}
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-flow5}dt content}
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/dev/manual/how-to-add-a-select-or-other-form-element.mld
+++ b/tutos/dev/manual/how-to-add-a-select-or-other-form-element.mld
@@ -35,7 +35,7 @@ Raw.select [option (txt "hello");
 
 {2 Links}
 
-- {{:how-to-write-forms.html}How to write forms}
+- {{!page-how-to-write-forms}How to write forms}
 - {{:https://ocsigen.org/eliom/latest/server-links.html}Eliom forms and links}
 - API
   {!Eliom.Content.Html.D.Form}

--- a/tutos/dev/manual/how-to-implement-a-notification-system.mld
+++ b/tutos/dev/manual/how-to-implement-a-notification-system.mld
@@ -31,7 +31,7 @@ This make possible to customize the notifications.
 Return [None] if you don't want him to be notified.
 
 For more information, have a look at
-{{:tutoreact.html}the tutorial
+{{!page-tutoreact}the tutorial
 about client-server reactive applications}.
 
 
@@ -72,9 +72,9 @@ And call function [notify] on the channel (from server side)
 when you want to notify the client.
 
 To get back the [notify] functions for one user, you may want to
-{{:how-to-iterate-on-all-sessions-for-one-user-or-all-tabs.html}iterate on all client process states}.
+{{!page-how-to-iterate-on-all-sessions-for-one-user-or-all-tabs}iterate on all client process states}.
 To do that, create a session group for each user
-(see {{:how-to-register-session-data.html}How to register session data}).
+(see {{!page-how-to-register-session-data}How to register session data}).
 Here we suppose that the session group name is the user_id, as a string.
 Then iterate on all sessions from this group, and on all client processes
 for each session.

--- a/tutos/dev/manual/how-to-make-hello-world-in-ocsigen.mld
+++ b/tutos/dev/manual/how-to-make-hello-world-in-ocsigen.mld
@@ -37,13 +37,13 @@ let _ =
 {2 }
 
 - To {e understand} this code, have a look at
-{{:how-does-a-page-s-source-code-look.html}How does a page's source code look?}
+{{!page-how-does-a-page-s-source-code-look}How does a page's source code look?}
 - Or directly continue by compiling this code:
-{{:how-to-compile-my-ocsigen-pages.html}How to compile my Ocsigen pages?}
+{{!page-how-to-compile-my-ocsigen-pages}How to compile my Ocsigen pages?}
 
 
 
 {2 Links}
 
-- {{:application.html}Tutorial to write a client/server application}
-- {{:interaction.html}Tutorial to write a server side web site}
+- {{!page-application}Tutorial to write a client/server application}
+- {{!page-interaction}Tutorial to write a server side web site}

--- a/tutos/dev/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
+++ b/tutos/dev/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
@@ -36,7 +36,7 @@ The style attribute specifies an inline style for an element. The style attribut
 
 Using this attribute to stylish elements is not a good practice.
 You should rather use
-{{:how-to-add-css-stylesheet.html}an external CSS file}.
+{{!page-how-to-add-css-stylesheet}an external CSS file}.
 
 Its parameter is a string.
 {@ocaml[~a:[a_style "color: pink; padding: 10px;"]]}

--- a/tutos/dev/manual/how-to-write-forms.mld
+++ b/tutos/dev/manual/how-to-write-forms.mld
@@ -107,4 +107,4 @@ using standard tyxml constructors.
 Use module {{:https://ocsigen.org/eliom/latest/eliom.server/Eliom/Content/Html/D/Raw/index.html}Eliom.Content.Html.D.Raw}.
 
 {2 Links}
-- {{:how-to-add-a-select-or-other-form-element.html}How to write a select (or other form element)?}
+- {{!page-how-to-add-a-select-or-other-form-element}How to write a select (or other form element)?}

--- a/tutos/dev/manual/how-to-write-titles-and-paragraphs.mld
+++ b/tutos/dev/manual/how-to-write-titles-and-paragraphs.mld
@@ -16,7 +16,7 @@ p [txt "Some text, blah blah blah"]
 
 {b Required parameter}: list containing other elements (content: {!Html_types.flow5} elements).
 
-{b Optional parameter} for attributes "a" ({{:how-to-set-and-id-classes-or-other-attributes-to-html-elements.html}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/dev/manual/interaction.mld
+++ b/tutos/dev/manual/interaction.mld
@@ -7,7 +7,7 @@
 This chapter of the tutorial explains how to create a small web site
 with several pages, users, sessions, and other elements of classical
 web development.  Then, in
-{{:misc.html}another tutorial}, we will incorporate the
+{{!page-misc}another tutorial}, we will incorporate the
 features of this site into our Graffiti application, to
 demonstrate that we can combine this kind of interaction with client-side
 programs.
@@ -368,7 +368,7 @@ and POST parameters. In that case, GET parameters will be in the URL
 and POST parameters will probably come from a form. In HTML, it is not
 possible to mix GET and POST parameters in the same form.
 
-See also {{:basics.html}the cheat-sheet} for an
+See also {{!page-basics}the cheat-sheet} for an
 comprehensive overview on the different types of services.
 
 {%wodoc:end%}
@@ -1257,5 +1257,5 @@ let () = Eliom.Content.Html.D.(
 )
 ]}
 
-{{:application.html}prev}
-{{:misc.html}next}
+{{!page-application}prev}
+{{!page-misc}next}

--- a/tutos/dev/manual/intro.mld
+++ b/tutos/dev/manual/intro.mld
@@ -53,24 +53,24 @@ new programming techniques to become autonomous.
 Depending on your level and goals, we suggest to continue by reading
 some of the following chapters:
 
-- Chapter {{:basics.html}Client-server application programming guide} can be used as your training plan.
+- Chapter {{!page-basics}Client-server application programming guide} can be used as your training plan.
 It provides a wide overview of each main concept, with links to more detailed
 documentation.
-- If you want to start with a server-side only Web site, read {{:basics-server.html}Server-side website programming guide} instead.
+- If you want to start with a server-side only Web site, read {{!page-basics-server}Server-side website programming guide} instead.
 - Then, a good starting point is this
-{{:start.html}Ocsigen Start tutorial},
+{{!page-start}Ocsigen Start tutorial},
 if you plan to build a client-server Web (and/or mobile) app.
 It will help you to build your first app very quickly,
 with many code samples to study.
 - If you are fluent in OCaml and want a quick introduction to
 client-server Web programming with Eliom,
 read tutorial
-{{:tutowidgets.html}Eliom apps basics: writing client server widgets}.
+{{!page-tutowidgets}Eliom apps basics: writing client server widgets}.
 It illusrates the client-server syntax with an example,
 and is a good starting point for understanding Eliom's client-server features.
 - If you want a full step-by-step tutorial on how to write a client-server Web
 application, read tutorial
-{{:application.html}Client-server application}.
+{{!page-application}Client-server application}.
 It describes step by step how to write a client/server
 {{:https://ocsigen.org/graffiti/}collaborative drawing application}. You will learn,
 from the very beginning, how to:
@@ -82,10 +82,10 @@ from the very beginning, how to:
 - {e Communicate} with the server, in both directions
 - Create services with {e non-HTML output}
 - If you want to build mobile applications,
-read tutorial {{:mobile.html}Mobile applications with Ocsigen}.
+read tutorial {{!page-mobile}Mobile applications with Ocsigen}.
 It describes how to build a mobile app (e.g., for Android)
 with the same codebase as for your Web application.
-- If you want to write a more traditional Web site, with pages, forms, and sessions, read tutorial {{:interaction.html}Service based Web programming}.
+- If you want to write a more traditional Web site, with pages, forms, and sessions, read tutorial {{!page-interaction}Service based Web programming}.
 It is devoted to server side programming.
 It shows how to
 create a new Web site with several pages and user connections.
@@ -96,7 +96,7 @@ You will learn how to:
 - Create services performing {e actions} (with no output)
 - Dynamically register new services ({e continuation based} Web programming)
 - If you want to learn more details about Ocsigen
-read tutorial {{:misc.html}Miscellaneous features}.
+read tutorial {{!page-misc}Miscellaneous features}.
 It will mix the client-server drawing application
 with the session mechanism and user management
 to produce a multi-user collaborative drawing
@@ -133,7 +133,7 @@ their {{:http://webchat.freenode.net/?channels=ocsigen}webchat})!
 
 
 Now, we recommend to read, chapter
-{{:basics.html}All Ocsigen in one page}
+{{!page-basics}All Ocsigen in one page}
 for a wide and complete overview.
 
 

--- a/tutos/dev/manual/misc.mld
+++ b/tutos/dev/manual/misc.mld
@@ -521,4 +521,4 @@ to [disconnect_box]
        canvas;])
 ]}
 
-{{:interaction.html}prev}
+{{!page-interaction}prev}

--- a/tutos/dev/manual/reactivemediaplayer.mld
+++ b/tutos/dev/manual/reactivemediaplayer.mld
@@ -1,6 +1,6 @@
 {0 Reactive Media Player}
 
-You should read the {{:music.html}Playing Music} tutorial before this one.
+You should read the {{!page-music}Playing Music} tutorial before this one.
 
 Since version 4, Eliom embeds the
 {{:http://erratique.ch/logiciel/react}React} library in order to
@@ -82,7 +82,7 @@ optional parameters of React.S functions producing a signal (like
 
 
 This part explains how to create a simple media player, similar to the
-{{:music.html}Playing Music} tutorial but with custom
+{{!page-music}Playing Music} tutorial but with custom
 controls.We will apply
 {{:https://en.wikipedia.org/wiki/Functional_reactive_programming}FRP (Functional Reactive Programming)}.
 

--- a/tutos/dev/manual/tutowidgets.mld
+++ b/tutos/dev/manual/tutowidgets.mld
@@ -7,7 +7,7 @@ It is probably a good starting point if you know OCaml well, and want
 to quickly learn how to write a client-server Eliom application with a
 short example and concise explanations.  For more detailed explanations, see
 the
-{{:application.html}"graffiti" tutorial},
+{{!page-application}"graffiti" tutorial},
 or read the manuals.
 
 The goal is to show that, unlike many JavaScript libraries that build
@@ -394,7 +394,7 @@ let%server _ = Eliom.Content.Html.D.(
 An important feature missing from this tutorial is the ability
 to call server functions from the client-side program ("server functions").
 You can find a quick description of this
-in {{:how-to-call-a-server-side-function-from-client-side.html}this mini HOWTO} or
+in {{!page-how-to-call-a-server-side-function-from-client-side}this mini HOWTO} or
 in {{:https://ocsigen.org/eliom/latest/clientserver-communication.html#rpc}Eliom's manual}.
 
 {2 Services}


### PR DESCRIPTION
## Why

The tutorial linked its own manual pages with the **external-link** form `{{:basics.html}label}` — a raw relative URL. odoc does not verify it (a typo or a renamed page silently 404s) and it only resolves by accident of the deployed flat layout. This is the same issue @Julow flagged on ocsigenserver.

## What

Convert all **108** internal page-to-page links (both the `8.0` and `dev` manuals) to proper **page references** `{{!page-name}label}`. odoc checks these at build time and they survive layout changes.

Left unchanged (correct as URLs): cross-project links (`/eliom/…`, `/ocsigen-start/…`, `/tuto/…`) and asset links (`files/…`).

## Verified locally

Built both versions with wodoc/odoc 3.2.1: every converted reference resolves (renders `<a href="basics.html" title="basics">…`), build exits 0, and there are **no new** unresolved-reference warnings (the remaining ones are pre-existing API refs to Eliom/Lwt/Js_of_ocaml types, unrelated).