### PR TITLE
doc: update the TyXML manual link to its new index.html

### DIFF
--- a/tutos/8.0/manual/html.mld
+++ b/tutos/8.0/manual/html.mld
@@ -154,6 +154,6 @@ which implements functional reactive programming for OCaml.
 
 {1 More documentation}
 
-Have a look at {{:https://ocsigen.org/tyxml/latest/tyxml/intro.html}Tyxml's manual}
+Have a look at {{:https://ocsigen.org/tyxml/latest/tyxml/index.html}Tyxml's manual}
 and {{:https://ocsigen.org/eliom/latest/clientserver-html.html}Eliom's manual}
 for more documentation about HTML manipulation in OCaml.

--- a/tutos/dev/manual/html.mld
+++ b/tutos/dev/manual/html.mld
@@ -154,6 +154,6 @@ which implements functional reactive programming for OCaml.
 
 {1 More documentation}
 
-Have a look at {{:https://ocsigen.org/tyxml/latest/tyxml/intro.html}Tyxml's manual}
+Have a look at {{:https://ocsigen.org/tyxml/latest/tyxml/index.html}Tyxml's manual}
 and {{:https://ocsigen.org/eliom/latest/clientserver-html.html}Eliom's manual}
 for more documentation about HTML manipulation in OCaml.


### PR DESCRIPTION
Companion to ocsigen/tyxml#358, which renames the TyXML introduction page from `intro.mld` to `index.mld` (so it becomes the package home page on ocaml.org). This updates the two tutorial links (8.0 and dev manuals) from `/tyxml/latest/tyxml/intro.html` to `…/index.html`.

Merge around the same time as tyxml#358 / the next TyXML release.