### PR TITLE
doc: list the full Ocsigen family in the hosted table

### DIFF
--- a/doc/wodoc
+++ b/doc/wodoc
@@ -10,10 +10,11 @@
 (menu-current tuto)
 (mld-package tuto)
 (flat)
-;; Sibling Ocsigen projects whose ocaml.org xrefs are rewritten to relative
-;; links into their wodoc docs:  (pkg deploy-dir layout wrapper-module)
-;; layout = true/multilib (<dir>.<side>/) | false/root (modules at version
-;; root) | subdir (each opam package under its own <pkg>/, whole family).
+
+;; Sibling Ocsigen projects, so wodoc rewrites their ocaml.org cross-references
+;; to relative links into their deployed docs on ocsigen.org. The full family is
+;; listed (not only the ones this doc currently links to) so that adding a link
+;; later never silently breaks. (pkg deploy-dir layout wrapper-module)
 (hosted
   (eliom           eliom           true  Eliom)
   (ocsigen-toolkit ocsigen-toolkit true  Ot)
@@ -21,4 +22,5 @@
   (ocsigenserver   ocsigenserver   false Ocsigen)
   (js_of_ocaml     js_of_ocaml     subdir)
   (tyxml           tyxml           subdir)
+  (lwt             lwt             subdir)
   (reactiveData    reactiveData    root))


### PR DESCRIPTION
The `(hosted …)` table now lists the **whole** Ocsigen family (eliom, toolkit, start, ocsigenserver, js_of_ocaml, tyxml, lwt, reactiveData), not only the projects this doc currently links to. This way, adding a cross-project link later is automatically rewritten for ocsigen.org instead of silently staying an unresolved reference. Same canonical table as eliom/toolkit/start.