### PR TITLE
doc: odoc references for cross-project + hyphenated page links

### DIFF
--- a/tutos/8.0/manual/application.mld
+++ b/tutos/8.0/manual/application.mld
@@ -23,7 +23,7 @@ If not already done, install Eliom first:
 opam install ocsipersist-sqlite eliom ocsigen-ppx-rpc
 v}
 
-To get started, we recommend using {{:https://ocsigen.org/eliom/latest/workflow-distillery.html}Eliom distillery}, a program which
+To get started, we recommend using {{!/eliom/page-"workflow-distillery"}Eliom distillery}, a program which
 creates scaffolds for Eliom projects. The following command creates a
 very simple project called [graffiti] in the directory
 [graffiti]:
@@ -146,7 +146,7 @@ pages as strings (as in other web frameworks). However, it is
 preferable to generate HTML in a way that provides compile-time HTML
 correctness guarantees. This tutorial achieves this by using the
 module {!Eliom_content.Html.D},
-which is implemented using the {{:https://ocsigen.org/tyxml/latest/}TyXML}
+which is implemented using the {{!/tyxml/page-index}TyXML}
 library.  The module defines a construction function for each HTML
 tag.
 
@@ -208,7 +208,7 @@ applications unrelated to Ocsigen.
 
 For now we will just use the [Lwt.return] function as above.  We
 will come back to Lwt programming later. You can also have a look at
-the {{:https://ocsigen.org/lwt/latest/}Lwt programming guide}.
+the {{!/lwt/page-index}Lwt programming guide}.
 
 {%wodoc:end%}
 
@@ -848,7 +848,7 @@ Functional Reactive Programming{%html:<br/>%}
 
 In this section, we add a color picker and slider to choose the size
 of the brush. For the colorpicker we used a widget available in
-{{:https://ocsigen.org/ocsigen-toolkit/latest/intro.html}Ocsigen Toolkit}.
+{{!/ocsigen-toolkit/page-intro}Ocsigen Toolkit}.
 
 To install Ocsigen Toolkit, do:
 {v
@@ -992,7 +992,7 @@ You can then test your application ([make test.byte]).
   client-server widgets
   for your Eliom applications. You can use it for building complex
   user interfaces. The full documentation is available
-  ({{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen Toolkit}).
+  ({{!/ocsigen-toolkit/page-index}Ocsigen Toolkit}).
 
 {%wodoc:end%}
 

--- a/tutos/8.0/manual/basics-server.mld
+++ b/tutos/8.0/manual/basics-server.mld
@@ -62,7 +62,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{!/lwt/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -343,7 +343,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{!/tyxml/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -491,7 +491,7 @@ above, plus one POST parameter of type string, named "mypostparam".
 {1 Eliom: Other kinds of services}
 {%wodoc:end%}
 
-The detailed explanation of services can be found in {{:https://ocsigen.org/eliom/latest/server-services.html}Eliom's manual}. Here is a summary:
+The detailed explanation of services can be found in {{!/eliom/page-"server-services"}Eliom's manual}. Here is a summary:
 
 {2 Pathless services}
 
@@ -542,7 +542,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom_service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os_lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
+{{!/eliom/page-"server-services"}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img
@@ -811,36 +811,36 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Staticmod}
+;{{!/ocsigenserver/page-staticmod}Staticmod}
 :    to serve static files.
-;{{:https://ocsigen.org/eliom/latest/}Eliom}
+;{{!/eliom/page-index}Eliom}
 :    to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{:https://ocsigen.org/ocsigenserver/latest/extendconfiguration.html}Extendconfiguration}
+;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
 :    allows for more options in the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/accesscontrol.html}Accesscontrol}
+;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
 :    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{:https://ocsigen.org/ocsigenserver/latest/authbasic.html}Authbasic}
+;{{!/ocsigenserver/page-authbasic}Authbasic}
 :    restricts access to the sites from the config file using Basic HTTP Authentication.
 ;CGImod
 :    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{:https://ocsigen.org/ocsigenserver/latest/deflatemod.html}Deflatemod}
+;{{!/ocsigenserver/page-deflatemod}Deflatemod}
 :    used to compress data before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/redirectmod.html}Redirectmod}
+;{{!/ocsigenserver/page-redirectmod}Redirectmod}
 :    sets redirections towards other Web sites from the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/revproxy.html}Revproxy}
+;{{!/ocsigenserver/page-revproxy}Revproxy}
 :    a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{:https://ocsigen.org/ocsigenserver/latest/rewritemod.html}Rewritemod}
+;{{!/ocsigenserver/page-rewritemod}Rewritemod}
 :    changes incoming requests before sending them to other extensions.
-;{{:https://ocsigen.org/ocsigenserver/latest/outputfilter.html}Outputfilter}
+;{{!/ocsigenserver/page-outputfilter}Outputfilter}
 :    rewrites some parts of the output before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/userconf.html}Userconf}
+;{{!/ocsigenserver/page-userconf}Userconf}
 :    allows users to have their own configuration files.
 ;Comet
 :    facilitates server to client communications.
 
-Ocsigen Server has a {{:https://ocsigen.org/ocsigenserver/latest/config.html}sophisticated configuration} file mechanism allowing
+Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.
 
 {%wodoc:end%}

--- a/tutos/8.0/manual/basics.mld
+++ b/tutos/8.0/manual/basics.mld
@@ -7,11 +7,11 @@ with Ocsigen. Use it as your training plan or as a cheat sheet while programming
 
 Depending on your needs, you may not need to learn all this. Ocsigen is
 very flexible and can be used both for Web site programming (see
-{{!page-basics-server}this page}) or more complex client-server Web apps and
+{{!page-"basics-server"}this page}) or more complex client-server Web apps and
 their mobile counterparts.
 
 In parallel to the reading of that page,
-we recommend to generate your first {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start} app to see
+we recommend to generate your first {{!/ocsigen-start/page-index}Ocsigen Start} app to see
 running examples of all these concepts (see {{!page-start}that page}).
 
 {%wodoc:div class="quickstart-block"%}
@@ -72,7 +72,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{!/lwt/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -200,7 +200,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{!/tyxml/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -341,7 +341,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom_service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os_lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
+{{!/eliom/page-"server-services"}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom_service} and {!Eliom_registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img
@@ -493,7 +493,7 @@ define a typed interface
 for form elements. Use this for links (see above), or if you program traditional
 server-side Web interaction (with or without client-side program). This will statically check that your forms
 match the services. See more information in the
-{{!page-basics-server}server-side programming manual}.
+{{!page-"basics-server"}server-side programming manual}.
 
 {%wodoc:end%}
 {%wodoc:section class="docblock"%}
@@ -628,7 +628,7 @@ an element (and more generally if you need to inject this element using [~%]).
 
 
 Read more about [Eliom_content.Html] (D or F?) in
-{{:https://ocsigen.org/eliom/latest/clientserver-html.html}this manual page}.
+{{!/eliom/page-"clientserver-html"}this manual page}.
 
 {%wodoc:end%}
 
@@ -847,7 +847,7 @@ the demo included in
 - {{!page-application}This page} is a step by step introduction to client-server programming with Eliom for beginners.
 - {{!page-tutowidgets}This one} is a quick introduction for more experienced OCaml developers.
 - Comprehensive documentation on client-server programming can be found in
-{{:https://ocsigen.org/eliom/latest/}Eliom's user manual}.
+{{!/eliom/page-index}Eliom's user manual}.
 {%wodoc:end%}
 
 {%wodoc:section class="docblock"%}
@@ -1311,36 +1311,36 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Staticmod}
+;{{!/ocsigenserver/page-staticmod}Staticmod}
 :    to serve static files.
-;{{:https://ocsigen.org/eliom/latest/}Eliom}
+;{{!/eliom/page-index}Eliom}
 :    to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{:https://ocsigen.org/ocsigenserver/latest/extendconfiguration.html}Extendconfiguration}
+;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
 :    allows for more options in the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/accesscontrol.html}Accesscontrol}
+;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
 :    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{:https://ocsigen.org/ocsigenserver/latest/authbasic.html}Authbasic}
+;{{!/ocsigenserver/page-authbasic}Authbasic}
 :    restricts access to the sites from the config file using Basic HTTP Authentication.
 ;CGImod
 :    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{:https://ocsigen.org/ocsigenserver/latest/deflatemod.html}Deflatemod}
+;{{!/ocsigenserver/page-deflatemod}Deflatemod}
 :    used to compress data before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/redirectmod.html}Redirectmod}
+;{{!/ocsigenserver/page-redirectmod}Redirectmod}
 :    sets redirections towards other Web sites from the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/revproxy.html}Revproxy}
+;{{!/ocsigenserver/page-revproxy}Revproxy}
 :    a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{:https://ocsigen.org/ocsigenserver/latest/rewritemod.html}Rewritemod}
+;{{!/ocsigenserver/page-rewritemod}Rewritemod}
 :    changes incoming requests before sending them to other extensions.
-;{{:https://ocsigen.org/ocsigenserver/latest/outputfilter.html}Outputfilter}
+;{{!/ocsigenserver/page-outputfilter}Outputfilter}
 :    rewrites some parts of the output before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/userconf.html}Userconf}
+;{{!/ocsigenserver/page-userconf}Userconf}
 :    allows users to have their own configuration files.
 ;Comet
 :    facilitates server to client communications.
 
-Ocsigen Server has a {{:https://ocsigen.org/ocsigenserver/latest/config.html}sophisticated configuration} file mechanism allowing
+Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.
 
 {%wodoc:end%}

--- a/tutos/8.0/manual/how-does-a-page-s-source-code-look.mld
+++ b/tutos/8.0/manual/how-does-a-page-s-source-code-look.mld
@@ -2,8 +2,8 @@
 
 {2 Eliom client-server applications}
 
-Eliom client-server applications are running in your browser for a {{:https://ocsigen.org/eliom/latest/clientserver-applications.html}certain lifetime} and consist of one or several pages/URLs.
-An application has its associated js file, which must have the same name ({{!page-how-to-compile-my-ocsigen-pages}generated automatically by the default makefile} and added automatically by Eliom in the page).
+Eliom client-server applications are running in your browser for a {{!/eliom/page-"clientserver-applications"}certain lifetime} and consist of one or several pages/URLs.
+An application has its associated js file, which must have the same name ({{!page-"how-to-compile-my-ocsigen-pages"}generated automatically by the default makefile} and added automatically by Eliom in the page).
 
 For example, we define an application called {e example}:
 {@ocaml[
@@ -31,7 +31,7 @@ The path is a list of string corresponding to the url. Here, the list is empty b
 If, for example, the list is ["hello";"world"], the page will be accessed using the address:
 {[http://website.com/hello/world/]}
 
-More information about parameters: {{!page-how-to-use-get-parameters-or-parameters-in-the-url}How to use GET parameters (parameters in the URL)?}
+More information about parameters: {{!page-"how-to-use-get-parameters-or-parameters-in-the-url"}How to use GET parameters (parameters in the URL)?}
 
 Now that our service has been declared, we associate to it an OCaml function that will generate the page. We call this {e service registration}. If the service belongs to the application, we use the registrations functions from module [Example] defined above.
 
@@ -77,5 +77,5 @@ W3C will be rejected at compile time.
 
 {2 Links}
 
-- {{:https://ocsigen.org/eliom/latest/server-services.html}About services}
-- {{:https://ocsigen.org/tyxml/latest/}About html generation}
+- {{!/eliom/page-"server-services"}About services}
+- {{!/tyxml/page-index}About html generation}

--- a/tutos/8.0/manual/how-to-add-a-div.mld
+++ b/tutos/8.0/manual/how-to-add-a-div.mld
@@ -8,7 +8,7 @@ div ~a:[a_class ["firstclass"; "secondclass"]] [txt "Hello!"]
 (Details of available elements in type
 {!Html_types.flow5}).
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/8.0/manual/how-to-add-a-favicon.mld
+++ b/tutos/8.0/manual/how-to-add-a-favicon.mld
@@ -12,5 +12,5 @@ Just put the file at the root of the static directory set in the configuration f
 
 {2 Links}
 
-- {{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Configuring Ocsigen Server for serving static files}
+- {{!/ocsigenserver/page-staticmod}Configuring Ocsigen Server for serving static files}
 - {{:http://www.favicon.cc/}An example of a favicon generator}

--- a/tutos/8.0/manual/how-to-add-a-list.mld
+++ b/tutos/8.0/manual/how-to-add-a-list.mld
@@ -23,7 +23,7 @@
 
 {b Required parameter}: list containing {b li} elements ({{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-li_attrib}Details of li content}).
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {3 Definition list}
 
@@ -53,7 +53,7 @@ Details:
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-phrasing}dd content}
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-flow5}dt content}
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/8.0/manual/how-to-add-a-select-or-other-form-element.mld
+++ b/tutos/8.0/manual/how-to-add-a-select-or-other-form-element.mld
@@ -35,8 +35,8 @@ Raw.select [option (txt "hello");
 
 {2 Links}
 
-- {{!page-how-to-write-forms}How to write forms}
-- {{:https://ocsigen.org/eliom/latest/server-links.html}Eliom forms and links}
+- {{!page-"how-to-write-forms"}How to write forms}
+- {{!/eliom/page-"server-links"}Eliom forms and links}
 - API
   {!Eliom_content.Html.D.Form}
 - signature {!Html_sigs.T} (Element attributes)

--- a/tutos/8.0/manual/how-to-add-css-stylesheet.mld
+++ b/tutos/8.0/manual/how-to-add-css-stylesheet.mld
@@ -40,6 +40,6 @@ Or you can use:
 
 {2 Links}
 
-- {{:https://ocsigen.org/eliom/latest/misc.html}About images, css and javascript}
+- {{!/eliom/page-misc}About images, css and javascript}
 - {!Eliom_content.Html.D.make_uri}
-- {{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Configuring Ocsigen Server for serving static files}
+- {{!/ocsigenserver/page-staticmod}Configuring Ocsigen Server for serving static files}

--- a/tutos/8.0/manual/how-to-compile-my-ocsigen-pages.mld
+++ b/tutos/8.0/manual/how-to-compile-my-ocsigen-pages.mld
@@ -15,10 +15,10 @@ Eliom distillery will also create a default configuration file for Ocsigen
 Server.
 
 More information on Eliom distillery in
-{{:https://ocsigen.org/eliom/latest/workflow-distillery.html}Eliom's manual}.
+{{!/eliom/page-"workflow-distillery"}Eliom's manual}.
 
 More information on how client-server Eliom project are compiled on
-{{:https://ocsigen.org/eliom/latest/workflow-configuration.html}this page}.
+{{!/eliom/page-"workflow-configuration"}this page}.
 
 If you don't need client-server features, the compilation process is very
 simple and without surprise. Compile with [ocamlc] or [ocamlopt]
@@ -38,4 +38,4 @@ Read manuals for mor information about these compilers.
 
 {2 Links}
 
-- {{:https://ocsigen.org/eliom/latest/workflow-configuration.html}Full documentation about Ocsigen compilation}
+- {{!/eliom/page-"workflow-configuration"}Full documentation about Ocsigen compilation}

--- a/tutos/8.0/manual/how-to-configure-and-launch-the-ocsigen-server.mld
+++ b/tutos/8.0/manual/how-to-configure-and-launch-the-ocsigen-server.mld
@@ -6,11 +6,11 @@
 - If you want to create it yourself, you can have a look at the default configuration file provided with the installation of Ocsigen (usually [/etc/ocsigenserver/ocsigenserver.conf.sample]).
 - Change the port by the network port number you want your website to work on. The port {b 80} is the port used by http by default but you need to be the administrator of your server to use it.
 - Adapt paths.
-- Change other parameters that suit your needs using the {{:https://ocsigen.org/ocsigenserver/latest/config.html}configuration file documentation}.
+- Change other parameters that suit your needs using the {{!/ocsigenserver/page-config}configuration file documentation}.
 
 {2 Your own configuration file}
 
-Have a look at the {{:https://ocsigen.org/ocsigenserver/latest/config.html}configuration file full documentation}.
+Have a look at the {{!/ocsigenserver/page-config}configuration file full documentation}.
 
 {2 Launch the server}
 
@@ -20,4 +20,4 @@ ocsigenserver -c your_config_file.conf
 
 {2 Links}
 
-- More information about this command or the configuration file in {{:https://ocsigen.org/ocsigenserver/latest/}Ocsigen Server's manual}.
+- More information about this command or the configuration file in {{!/ocsigenserver/page-index}Ocsigen Server's manual}.

--- a/tutos/8.0/manual/how-to-implement-a-notification-system.mld
+++ b/tutos/8.0/manual/how-to-implement-a-notification-system.mld
@@ -72,9 +72,9 @@ And call function [notify] on the channel (from server side)
 when you want to notify the client.
 
 To get back the [notify] functions for one user, you may want to
-{{!page-how-to-iterate-on-all-sessions-for-one-user-or-all-tabs}iterate on all client process states}.
+{{!page-"how-to-iterate-on-all-sessions-for-one-user-or-all-tabs"}iterate on all client process states}.
 To do that, create a session group for each user
-(see {{!page-how-to-register-session-data}How to register session data}).
+(see {{!page-"how-to-register-session-data"}How to register session data}).
 Here we suppose that the session group name is the user_id, as a string.
 Then iterate on all sessions from this group, and on all client processes
 for each session.

--- a/tutos/8.0/manual/how-to-make-hello-world-in-ocsigen.mld
+++ b/tutos/8.0/manual/how-to-make-hello-world-in-ocsigen.mld
@@ -37,9 +37,9 @@ let _ =
 {2 }
 
 - To {e understand} this code, have a look at
-{{!page-how-does-a-page-s-source-code-look}How does a page's source code look?}
+{{!page-"how-does-a-page-s-source-code-look"}How does a page's source code look?}
 - Or directly continue by compiling this code:
-{{!page-how-to-compile-my-ocsigen-pages}How to compile my Ocsigen pages?}
+{{!page-"how-to-compile-my-ocsigen-pages"}How to compile my Ocsigen pages?}
 
 
 

--- a/tutos/8.0/manual/how-to-register-session-data.mld
+++ b/tutos/8.0/manual/how-to-register-session-data.mld
@@ -70,5 +70,5 @@ if you restart the server.
 
 {1 Links}
 
-- {{:https://ocsigen.org/eliom/latest/server-state.html}More information on session data}
+- {{!/eliom/page-"server-state"}More information on session data}
 - module {!Eliom_reference}

--- a/tutos/8.0/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
+++ b/tutos/8.0/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
@@ -36,7 +36,7 @@ The style attribute specifies an inline style for an element. The style attribut
 
 Using this attribute to stylish elements is not a good practice.
 You should rather use
-{{!page-how-to-add-css-stylesheet}an external CSS file}.
+{{!page-"how-to-add-css-stylesheet"}an external CSS file}.
 
 Its parameter is a string.
 {@ocaml[~a:[a_style "color: pink; padding: 10px;"]]}

--- a/tutos/8.0/manual/how-to-use-get-parameters-or-parameters-in-the-url.mld
+++ b/tutos/8.0/manual/how-to-use-get-parameters-or-parameters-in-the-url.mld
@@ -43,7 +43,7 @@ We recommend to open this module (at the beginning of your file, or locally).
 - {b Common types}: {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L121}string}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L122}int}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L123}int32}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L124}float}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L125}bool}
 - {b Some other types}: {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L126}optional values}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L158}any parameter}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L187}list}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L211}your own type}.
 
-- See more information on parameters in {{:https://ocsigen.org/eliom/latest/server-params.html}Eliom manual} and API documentation of module {!Eliom_parameter}.
+- See more information on parameters in {{!/eliom/page-"server-params"}Eliom manual} and API documentation of module {!Eliom_parameter}.
 
 {3 Get these parameters}
 
@@ -82,7 +82,7 @@ To do that, add a parameter of type {b suffix} in {b get_params}:
 
 {2 Links}
 
-- Manual: {{:https://ocsigen.org/eliom/latest/server-params.html}Parameters}
-- Manual: {{:https://ocsigen.org/eliom/latest/server-services.html}Services}
+- Manual: {{!/eliom/page-"server-params"}Parameters}
+- Manual: {{!/eliom/page-"server-services"}Services}
 - API: {!Eliom_parameter}
 - API: {!Eliom_service}

--- a/tutos/8.0/manual/how-to-write-forms.mld
+++ b/tutos/8.0/manual/how-to-write-forms.mld
@@ -107,4 +107,4 @@ using standard tyxml constructors.
 Use module {{:https://ocsigen.org/eliom/latest/eliom.server/Eliom/Content/Html/D/Raw/index.html}Eliom_content.Html.D.Raw}.
 
 {2 Links}
-- {{!page-how-to-add-a-select-or-other-form-element}How to write a select (or other form element)?}
+- {{!page-"how-to-add-a-select-or-other-form-element"}How to write a select (or other form element)?}

--- a/tutos/8.0/manual/how-to-write-titles-and-paragraphs.mld
+++ b/tutos/8.0/manual/how-to-write-titles-and-paragraphs.mld
@@ -16,7 +16,7 @@ p [txt "Some text, blah blah blah"]
 
 {b Required parameter}: list containing other elements (content: {!Html_types.flow5} elements).
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/8.0/manual/html.mld
+++ b/tutos/8.0/manual/html.mld
@@ -155,5 +155,5 @@ which implements functional reactive programming for OCaml.
 {1 More documentation}
 
 Have a look at {{:https://ocsigen.org/tyxml/latest/tyxml/index.html}Tyxml's manual}
-and {{:https://ocsigen.org/eliom/latest/clientserver-html.html}Eliom's manual}
+and {{!/eliom/page-"clientserver-html"}Eliom's manual}
 for more documentation about HTML manipulation in OCaml.

--- a/tutos/8.0/manual/interaction.mld
+++ b/tutos/8.0/manual/interaction.mld
@@ -392,7 +392,7 @@ Remember:
 {e Warning:} Even if POST parameters are not shown in the URL, they
 are sent as plain text. If you want to transmit private data (like a password),
 you must
-use HTTPS (see {{:https://ocsigen.org/ocsigenserver/latest/config.html}the Ocsigen server manual}).  {%wodoc:end%}
+use HTTPS (see {{!/ocsigenserver/page-config}the Ocsigen server manual}).  {%wodoc:end%}
 
 Now we can register a handler for the new service:
 

--- a/tutos/8.0/manual/intro.mld
+++ b/tutos/8.0/manual/intro.mld
@@ -35,14 +35,14 @@ at the {{:https://www.besport.com/news}Be Sport social network} (available in
 Ocsigen consists of several quite independent projects, all
 released as open source software on {{:https://github.com/ocsigen}Github}.
 The main projects are:
-- {{:https://ocsigen.org/lwt/latest/}Lwt}, a general purpose concurrent programming library for OCaml,
-- {{:https://ocsigen.org/tyxml/latest/}TyXML} for generating typed XML,
-- the {{:https://ocsigen.org/js_of_ocaml/latest/}Js_of_ocaml} compiler (from Ocaml bytecode to JavaScript),
-- {{:https://ocsigen.org/eliom/latest/}Eliom}, the multi-tier framework for client-server
+- {{!/lwt/page-index}Lwt}, a general purpose concurrent programming library for OCaml,
+- {{!/tyxml/page-index}TyXML} for generating typed XML,
+- the {{!/js_of_ocaml/page-index}Js_of_ocaml} compiler (from Ocaml bytecode to JavaScript),
+- {{!/eliom/page-index}Eliom}, the multi-tier framework for client-server
 Web and mobile apps,
-- {{:https://ocsigen.org/ocsigenserver/latest/}Ocsigen Server}, a full-featured Web server,
-- {{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen Toolkit}, a client-server widget library written for Eliom and Js_of_ocaml,
-- {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start}, an application template with
+- {{!/ocsigenserver/page-index}Ocsigen Server}, a full-featured Web server,
+- {{!/ocsigen-toolkit/page-index}Ocsigen Toolkit}, a client-server widget library written for Eliom and Js_of_ocaml,
+- {{!/ocsigen-start/page-index}Ocsigen Start}, an application template with
 many code examples, to be used as a basis for your apps, or to learn.
 
 The {{:https://ocsigen.org/install}installation is described here}.
@@ -56,7 +56,7 @@ some of the following chapters:
 - Chapter {{!page-basics}Client-server application programming guide} can be used as your training plan.
 It provides a wide overview of each main concept, with links to more detailed
 documentation.
-- If you want to start with a server-side only Web site, read {{!page-basics-server}Server-side website programming guide} instead.
+- If you want to start with a server-side only Web site, read {{!page-"basics-server"}Server-side website programming guide} instead.
 - Then, a good starting point is this
 {{!page-start}Ocsigen Start tutorial},
 if you plan to build a client-server Web (and/or mobile) app.
@@ -108,7 +108,7 @@ application.  In this chapter, you will learn how to:
 - Add an Atom feed
 - If you want to have a full application with user management
 (registration, activation emails, authentication),
-have a look at {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen-start}.
+have a look at {{!/ocsigen-start/page-index}Ocsigen-start}.
 Ocsigen-start is a library and a template for Eliom distillery that
 contains a working Eliom application with user and right
 management.

--- a/tutos/8.0/manual/lwt.mld
+++ b/tutos/8.0/manual/lwt.mld
@@ -172,7 +172,7 @@ let rec map_serial f l =
 
 {1 More documentation}
 
-Have a look at {{:https://ocsigen.org/lwt/latest/}Lwt's manual}
+Have a look at {{!/lwt/page-index}Lwt's manual}
 for more details about Lwt.
 You will learn how to handle exceptions (using [Lwt.fail]
 and [Lwt.catch] or [try%lwt]).

--- a/tutos/8.0/manual/macaque.mld
+++ b/tutos/8.0/manual/macaque.mld
@@ -14,7 +14,7 @@ time and makes difficult to generate queries at compile time.
 Macaque uses its own syntax, whereas PGOcaml uses SQL.
 Macaque supports only a small subset of Postgresql features.
 
-Warning: Macaque's syntax extension uses camlp4, which is not compatible with ppx. If you want to use macaque with Eliom's ppx, place your macaque code in an isolated file. Some details can be found in {{:https://ocsigen.org/eliom/latest/ppx-migration.html}the ppx migration guide}.
+Warning: Macaque's syntax extension uses camlp4, which is not compatible with ppx. If you want to use macaque with Eliom's ppx, place your macaque code in an isolated file. Some details can be found in {{!/eliom/page-"ppx-migration"}the ppx migration guide}.
 
 This tutorial shows how to store the login and the password
 f users in a Postgresql

--- a/tutos/8.0/manual/misc.mld
+++ b/tutos/8.0/manual/misc.mld
@@ -86,7 +86,7 @@ let stop_drawing { message_thread; drawing_thread } =
 
 [Lwt.cancel t] stops thread t. In this case it also closes the
   bus on which t is listening. For more informations see the
-  {{:https://ocsigen.org/lwt/latest/}Lwt programming guide} and
+  {{!/lwt/page-index}Lwt programming guide} and
   {!Eliom_bus}.
 
 {@ocaml[

--- a/tutos/8.0/manual/mobile.mld
+++ b/tutos/8.0/manual/mobile.mld
@@ -8,7 +8,7 @@ fact, one single codebase can be used to produce all these
 applications simultaneously.
 
 The easiest way to get started with Ocsigen-based mobile development
-is to use {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen-start}.  Ocsigen-start is a
+is to use {{!/ocsigen-start/page-index}Ocsigen-start}.  Ocsigen-start is a
 library and skeleton for building "minimum viable product" Web
 applications with standard functionality like users, notifications,
 etc. This skeleton is immediately usable as a mobile application. You
@@ -23,7 +23,7 @@ template's [README.md].
 
 You need to follow a certain programming style for your Eliom code to
 work flawlessly inside an Ocsigen-start mobile app. This style is
-described in the {{:https://ocsigen.org/eliom/latest/clientserver-services.html}chapter on
+described in the {{!/eliom/page-"clientserver-services"}chapter on
 client services} from the Eliom manual. The idea is that you
 implement as much of your application as possible in shared sections
 ([[%%shared ...]] or [let%shared ... = ...]), and that you
@@ -34,7 +34,7 @@ inspiration.
 
 {1 Going further}
 
-- {{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen-toolkit} provides a set of user
+- {{!/ocsigen-toolkit/page-index}Ocsigen-toolkit} provides a set of user
   interface widgets that are particularly useful for mobile applications.
 
 - Danny Willems provides a comprehensive set of

--- a/tutos/8.0/manual/start.mld
+++ b/tutos/8.0/manual/start.mld
@@ -13,7 +13,7 @@ functionality like users and notifications in only a few minutes. This
 template can be used for learning purposes, or even as a starting
 point for your own product.
 
-The template you will use comes from {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start}.
+The template you will use comes from {{!/ocsigen-start/page-index}Ocsigen Start}.
 Ocsigen Start provides a complete mechanism for adding and managing
 users, including activation links and password reset. It additionally
 contains a module for displaying tips, a module for sending
@@ -77,7 +77,7 @@ you:
 - How to save session data (in {e Eliom references});
 - How to use the notification system;
 - How to create reactive pages;
-- Many examples of widgets from {{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen Toolkit}:
+- Many examples of widgets from {{!/ocsigen-toolkit/page-index}Ocsigen Toolkit}:
 - Carousel
 - Pages with several tabs
 - Time and date pickers

--- a/tutos/8.0/manual/tutowidgets.mld
+++ b/tutos/8.0/manual/tutowidgets.mld
@@ -394,7 +394,7 @@ let%server _ = Eliom_content.Html.D.(
 An important feature missing from this tutorial is the ability
 to call server functions from the client-side program ("server functions").
 You can find a quick description of this
-in {{!page-how-to-call-a-server-side-function-from-client-side}this mini HOWTO} or
+in {{!page-"how-to-call-a-server-side-function-from-client-side"}this mini HOWTO} or
 in {{:https://ocsigen.org/eliom/latest/clientserver-communication.html#rpc}Eliom's manual}.
 
 {2 Services}
@@ -409,8 +409,8 @@ parameters), or by a session identifier (we call this kind of service
 a {e coservice}). Eliom also allows creating new (co-)services
 dynamically, for example coservices depending on previous interaction
 with a user. More information on the service identification mechanism
-in {{:https://ocsigen.org/eliom/latest/server-services.html}Eliom's manual}.
+in {{!/eliom/page-"server-services"}Eliom's manual}.
 
 {2 Sessions}
 Eliom also offers a rich session mechanism, with {e scopes}
-(see {{:https://ocsigen.org/eliom/latest/server-state.html}Eliom's manual}).
+(see {{!/eliom/page-"server-state"}Eliom's manual}).

--- a/tutos/dev/manual/application.mld
+++ b/tutos/dev/manual/application.mld
@@ -23,7 +23,7 @@ If not already done, install Eliom first:
 opam install ocsipersist-sqlite eliom ocsigen-ppx-rpc
 v}
 
-To get started, we recommend using {{:https://ocsigen.org/eliom/latest/workflow-distillery.html}Eliom distillery}, a program which
+To get started, we recommend using {{!/eliom/page-"workflow-distillery"}Eliom distillery}, a program which
 creates scaffolds for Eliom projects. The following command creates a
 very simple project called [graffiti] in the directory
 [graffiti]:
@@ -146,7 +146,7 @@ pages as strings (as in other web frameworks). However, it is
 preferable to generate HTML in a way that provides compile-time HTML
 correctness guarantees. This tutorial achieves this by using the
 module {!Eliom.Content.Html.D},
-which is implemented using the {{:https://ocsigen.org/tyxml/latest/}TyXML}
+which is implemented using the {{!/tyxml/page-index}TyXML}
 library.  The module defines a construction function for each HTML
 tag.
 
@@ -208,7 +208,7 @@ applications unrelated to Ocsigen.
 
 For now we will just use the [Lwt.return] function as above.  We
 will come back to Lwt programming later. You can also have a look at
-the {{:https://ocsigen.org/lwt/latest/}Lwt programming guide}.
+the {{!/lwt/page-index}Lwt programming guide}.
 
 {%wodoc:end%}
 
@@ -848,7 +848,7 @@ Functional Reactive Programming{%html:<br/>%}
 
 In this section, we add a color picker and slider to choose the size
 of the brush. For the colorpicker we used a widget available in
-{{:https://ocsigen.org/ocsigen-toolkit/latest/intro.html}Ocsigen Toolkit}.
+{{!/ocsigen-toolkit/page-intro}Ocsigen Toolkit}.
 
 To install Ocsigen Toolkit, do:
 {v
@@ -992,7 +992,7 @@ You can then test your application ([make test.byte]).
   client-server widgets
   for your Eliom applications. You can use it for building complex
   user interfaces. The full documentation is available
-  ({{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen Toolkit}).
+  ({{!/ocsigen-toolkit/page-index}Ocsigen Toolkit}).
 
 {%wodoc:end%}
 

--- a/tutos/dev/manual/basics-server.mld
+++ b/tutos/dev/manual/basics-server.mld
@@ -62,7 +62,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{!/lwt/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -343,7 +343,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{!/tyxml/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -491,7 +491,7 @@ above, plus one POST parameter of type string, named "mypostparam".
 {1 Eliom: Other kinds of services}
 {%wodoc:end%}
 
-The detailed explanation of services can be found in {{:https://ocsigen.org/eliom/latest/server-services.html}Eliom's manual}. Here is a summary:
+The detailed explanation of services can be found in {{!/eliom/page-"server-services"}Eliom's manual}. Here is a summary:
 
 {2 Pathless services}
 
@@ -542,7 +542,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom.Service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os.Lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
+{{!/eliom/page-"server-services"}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img
@@ -811,36 +811,36 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Staticmod}
+;{{!/ocsigenserver/page-staticmod}Staticmod}
 :    to serve static files.
-;{{:https://ocsigen.org/eliom/latest/}Eliom}
+;{{!/eliom/page-index}Eliom}
 :    to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{:https://ocsigen.org/ocsigenserver/latest/extendconfiguration.html}Extendconfiguration}
+;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
 :    allows for more options in the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/accesscontrol.html}Accesscontrol}
+;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
 :    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{:https://ocsigen.org/ocsigenserver/latest/authbasic.html}Authbasic}
+;{{!/ocsigenserver/page-authbasic}Authbasic}
 :    restricts access to the sites from the config file using Basic HTTP Authentication.
 ;CGImod
 :    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{:https://ocsigen.org/ocsigenserver/latest/deflatemod.html}Deflatemod}
+;{{!/ocsigenserver/page-deflatemod}Deflatemod}
 :    used to compress data before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/redirectmod.html}Redirectmod}
+;{{!/ocsigenserver/page-redirectmod}Redirectmod}
 :    sets redirections towards other Web sites from the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/revproxy.html}Revproxy}
+;{{!/ocsigenserver/page-revproxy}Revproxy}
 :    a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{:https://ocsigen.org/ocsigenserver/latest/rewritemod.html}Rewritemod}
+;{{!/ocsigenserver/page-rewritemod}Rewritemod}
 :    changes incoming requests before sending them to other extensions.
-;{{:https://ocsigen.org/ocsigenserver/latest/outputfilter.html}Outputfilter}
+;{{!/ocsigenserver/page-outputfilter}Outputfilter}
 :    rewrites some parts of the output before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/userconf.html}Userconf}
+;{{!/ocsigenserver/page-userconf}Userconf}
 :    allows users to have their own configuration files.
 ;Comet
 :    facilitates server to client communications.
 
-Ocsigen Server has a {{:https://ocsigen.org/ocsigenserver/latest/config.html}sophisticated configuration} file mechanism allowing
+Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.
 
 {%wodoc:end%}

--- a/tutos/dev/manual/basics.mld
+++ b/tutos/dev/manual/basics.mld
@@ -7,11 +7,11 @@ with Ocsigen. Use it as your training plan or as a cheat sheet while programming
 
 Depending on your needs, you may not need to learn all this. Ocsigen is
 very flexible and can be used both for Web site programming (see
-{{!page-basics-server}this page}) or more complex client-server Web apps and
+{{!page-"basics-server"}this page}) or more complex client-server Web apps and
 their mobile counterparts.
 
 In parallel to the reading of that page,
-we recommend to generate your first {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start} app to see
+we recommend to generate your first {{!/ocsigen-start/page-index}Ocsigen Start} app to see
 running examples of all these concepts (see {{!page-start}that page}).
 
 {%wodoc:div class="quickstart-block"%}
@@ -72,7 +72,7 @@ and makes it very natural to sequentialize computations without blocking the res
 of the program.
 {%wodoc:end%}
 
-To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{:https://ocsigen.org/lwt/latest/}user manual}.
+To learn Lwt, read this {{!page-lwt}short tutorial}, or its {{!/lwt/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -200,7 +200,7 @@ Error: This expression has type
             | `Wbr ]
        The second variant type does not allow tag(s) `P
 ]}
-Read more about TyXML in this {{!page-html}short tutorial} or in its {{:https://ocsigen.org/tyxml/latest/}user manual}.
+Read more about TyXML in this {{!page-html}short tutorial} or in its {{!/tyxml/page-index}user manual}.
 
 {%wodoc:end%}
 
@@ -341,7 +341,7 @@ to create links towards static files (see example below for images).
 
 Use service {!Eliom.Service.reload_action} and its variants to create links or forms towards the current URL (reload the page). From a client section, you can also call {!Os.Lib.reload} to reload the page and restart the client-side program.
 
-{{:https://ocsigen.org/eliom/latest/server-services.html}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
+{{!/eliom/page-"server-services"}Full documentation about services}, {{!page-interaction}a tutorial about traditional service based Web programming}, API documentation of modules {!Eliom.Service} and {!Eliom.Registration}.
 
 This example shows how to insert an image using [static_dir]:
 {@ocaml[img
@@ -493,7 +493,7 @@ define a typed interface
 for form elements. Use this for links (see above), or if you program traditional
 server-side Web interaction (with or without client-side program). This will statically check that your forms
 match the services. See more information in the
-{{!page-basics-server}server-side programming manual}.
+{{!page-"basics-server"}server-side programming manual}.
 
 {%wodoc:end%}
 {%wodoc:section class="docblock"%}
@@ -628,7 +628,7 @@ an element (and more generally if you need to inject this element using [~%]).
 
 
 Read more about [Eliom.Content.Html] (D or F?) in
-{{:https://ocsigen.org/eliom/latest/clientserver-html.html}this manual page}.
+{{!/eliom/page-"clientserver-html"}this manual page}.
 
 {%wodoc:end%}
 
@@ -847,7 +847,7 @@ the demo included in
 - {{!page-application}This page} is a step by step introduction to client-server programming with Eliom for beginners.
 - {{!page-tutowidgets}This one} is a quick introduction for more experienced OCaml developers.
 - Comprehensive documentation on client-server programming can be found in
-{{:https://ocsigen.org/eliom/latest/}Eliom's user manual}.
+{{!/eliom/page-index}Eliom's user manual}.
 {%wodoc:end%}
 
 {%wodoc:section class="docblock"%}
@@ -1311,36 +1311,36 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Staticmod}
+;{{!/ocsigenserver/page-staticmod}Staticmod}
 :    to serve static files.
-;{{:https://ocsigen.org/eliom/latest/}Eliom}
+;{{!/eliom/page-index}Eliom}
 :    to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{:https://ocsigen.org/ocsigenserver/latest/extendconfiguration.html}Extendconfiguration}
+;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
 :    allows for more options in the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/accesscontrol.html}Accesscontrol}
+;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
 :    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{:https://ocsigen.org/ocsigenserver/latest/authbasic.html}Authbasic}
+;{{!/ocsigenserver/page-authbasic}Authbasic}
 :    restricts access to the sites from the config file using Basic HTTP Authentication.
 ;CGImod
 :    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{:https://ocsigen.org/ocsigenserver/latest/deflatemod.html}Deflatemod}
+;{{!/ocsigenserver/page-deflatemod}Deflatemod}
 :    used to compress data before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/redirectmod.html}Redirectmod}
+;{{!/ocsigenserver/page-redirectmod}Redirectmod}
 :    sets redirections towards other Web sites from the configuration file.
-;{{:https://ocsigen.org/ocsigenserver/latest/revproxy.html}Revproxy}
+;{{!/ocsigenserver/page-revproxy}Revproxy}
 :    a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{:https://ocsigen.org/ocsigenserver/latest/rewritemod.html}Rewritemod}
+;{{!/ocsigenserver/page-rewritemod}Rewritemod}
 :    changes incoming requests before sending them to other extensions.
-;{{:https://ocsigen.org/ocsigenserver/latest/outputfilter.html}Outputfilter}
+;{{!/ocsigenserver/page-outputfilter}Outputfilter}
 :    rewrites some parts of the output before sending it to the client.
-;{{:https://ocsigen.org/ocsigenserver/latest/userconf.html}Userconf}
+;{{!/ocsigenserver/page-userconf}Userconf}
 :    allows users to have their own configuration files.
 ;Comet
 :    facilitates server to client communications.
 
-Ocsigen Server has a {{:https://ocsigen.org/ocsigenserver/latest/config.html}sophisticated configuration} file mechanism allowing
+Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.
 
 {%wodoc:end%}

--- a/tutos/dev/manual/how-does-a-page-s-source-code-look.mld
+++ b/tutos/dev/manual/how-does-a-page-s-source-code-look.mld
@@ -2,8 +2,8 @@
 
 {2 Eliom client-server applications}
 
-Eliom client-server applications are running in your browser for a {{:https://ocsigen.org/eliom/latest/clientserver-applications.html}certain lifetime} and consist of one or several pages/URLs.
-An application has its associated js file, which must have the same name ({{!page-how-to-compile-my-ocsigen-pages}generated automatically by the default makefile} and added automatically by Eliom in the page).
+Eliom client-server applications are running in your browser for a {{!/eliom/page-"clientserver-applications"}certain lifetime} and consist of one or several pages/URLs.
+An application has its associated js file, which must have the same name ({{!page-"how-to-compile-my-ocsigen-pages"}generated automatically by the default makefile} and added automatically by Eliom in the page).
 
 For example, we define an application called {e example}:
 {@ocaml[
@@ -31,7 +31,7 @@ The path is a list of string corresponding to the url. Here, the list is empty b
 If, for example, the list is ["hello";"world"], the page will be accessed using the address:
 {[http://website.com/hello/world/]}
 
-More information about parameters: {{!page-how-to-use-get-parameters-or-parameters-in-the-url}How to use GET parameters (parameters in the URL)?}
+More information about parameters: {{!page-"how-to-use-get-parameters-or-parameters-in-the-url"}How to use GET parameters (parameters in the URL)?}
 
 Now that our service has been declared, we associate to it an OCaml function that will generate the page. We call this {e service registration}. If the service belongs to the application, we use the registrations functions from module [Example] defined above.
 
@@ -77,5 +77,5 @@ W3C will be rejected at compile time.
 
 {2 Links}
 
-- {{:https://ocsigen.org/eliom/latest/server-services.html}About services}
-- {{:https://ocsigen.org/tyxml/latest/}About html generation}
+- {{!/eliom/page-"server-services"}About services}
+- {{!/tyxml/page-index}About html generation}

--- a/tutos/dev/manual/how-to-add-a-div.mld
+++ b/tutos/dev/manual/how-to-add-a-div.mld
@@ -8,7 +8,7 @@ div ~a:[a_class ["firstclass"; "secondclass"]] [txt "Hello!"]
 (Details of available elements in type
 {!Html_types.flow5}).
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/dev/manual/how-to-add-a-favicon.mld
+++ b/tutos/dev/manual/how-to-add-a-favicon.mld
@@ -12,5 +12,5 @@ Just put the file at the root of the static directory set in the configuration f
 
 {2 Links}
 
-- {{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Configuring Ocsigen Server for serving static files}
+- {{!/ocsigenserver/page-staticmod}Configuring Ocsigen Server for serving static files}
 - {{:http://www.favicon.cc/}An example of a favicon generator}

--- a/tutos/dev/manual/how-to-add-a-list.mld
+++ b/tutos/dev/manual/how-to-add-a-list.mld
@@ -23,7 +23,7 @@
 
 {b Required parameter}: list containing {b li} elements ({{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-li_attrib}Details of li content}).
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {3 Definition list}
 
@@ -53,7 +53,7 @@ Details:
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-phrasing}dd content}
 - {{:https://ocsigen.org/tyxml/latest/tyxml/Html_types/index.html#type-flow5}dt content}
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/dev/manual/how-to-add-a-select-or-other-form-element.mld
+++ b/tutos/dev/manual/how-to-add-a-select-or-other-form-element.mld
@@ -35,8 +35,8 @@ Raw.select [option (txt "hello");
 
 {2 Links}
 
-- {{!page-how-to-write-forms}How to write forms}
-- {{:https://ocsigen.org/eliom/latest/server-links.html}Eliom forms and links}
+- {{!page-"how-to-write-forms"}How to write forms}
+- {{!/eliom/page-"server-links"}Eliom forms and links}
 - API
   {!Eliom.Content.Html.D.Form}
 - signature {!Html_sigs.T} (Element attributes)

--- a/tutos/dev/manual/how-to-add-css-stylesheet.mld
+++ b/tutos/dev/manual/how-to-add-css-stylesheet.mld
@@ -40,6 +40,6 @@ Or you can use:
 
 {2 Links}
 
-- {{:https://ocsigen.org/eliom/latest/misc.html}About images, css and javascript}
+- {{!/eliom/page-misc}About images, css and javascript}
 - {!Eliom.Content.Html.D.make_uri}
-- {{:https://ocsigen.org/ocsigenserver/latest/staticmod.html}Configuring Ocsigen Server for serving static files}
+- {{!/ocsigenserver/page-staticmod}Configuring Ocsigen Server for serving static files}

--- a/tutos/dev/manual/how-to-compile-my-ocsigen-pages.mld
+++ b/tutos/dev/manual/how-to-compile-my-ocsigen-pages.mld
@@ -15,10 +15,10 @@ Eliom distillery will also create a default configuration file for Ocsigen
 Server.
 
 More information on Eliom distillery in
-{{:https://ocsigen.org/eliom/latest/workflow-distillery.html}Eliom's manual}.
+{{!/eliom/page-"workflow-distillery"}Eliom's manual}.
 
 More information on how client-server Eliom project are compiled on
-{{:https://ocsigen.org/eliom/latest/workflow-configuration.html}this page}.
+{{!/eliom/page-"workflow-configuration"}this page}.
 
 If you don't need client-server features, the compilation process is very
 simple and without surprise. Compile with [ocamlc] or [ocamlopt]
@@ -42,4 +42,4 @@ Read manuals for mor information about these compilers.
 
 {2 Links}
 
-- {{:https://ocsigen.org/eliom/latest/workflow-configuration.html}Full documentation about Ocsigen compilation}
+- {{!/eliom/page-"workflow-configuration"}Full documentation about Ocsigen compilation}

--- a/tutos/dev/manual/how-to-configure-and-launch-the-ocsigen-server.mld
+++ b/tutos/dev/manual/how-to-configure-and-launch-the-ocsigen-server.mld
@@ -6,11 +6,11 @@
 - If you want to create it yourself, you can have a look at the default configuration file provided with the installation of Ocsigen (usually [/etc/ocsigenserver/ocsigenserver.conf.sample]).
 - Change the port by the network port number you want your website to work on. The port {b 80} is the port used by http by default but you need to be the administrator of your server to use it.
 - Adapt paths.
-- Change other parameters that suit your needs using the {{:https://ocsigen.org/ocsigenserver/latest/config.html}configuration file documentation}.
+- Change other parameters that suit your needs using the {{!/ocsigenserver/page-config}configuration file documentation}.
 
 {2 Your own configuration file}
 
-Have a look at the {{:https://ocsigen.org/ocsigenserver/latest/config.html}configuration file full documentation}.
+Have a look at the {{!/ocsigenserver/page-config}configuration file full documentation}.
 
 {2 Launch the server}
 
@@ -20,4 +20,4 @@ ocsigenserver -c your_config_file.conf
 
 {2 Links}
 
-- More information about this command or the configuration file in {{:https://ocsigen.org/ocsigenserver/latest/}Ocsigen Server's manual}.
+- More information about this command or the configuration file in {{!/ocsigenserver/page-index}Ocsigen Server's manual}.

--- a/tutos/dev/manual/how-to-implement-a-notification-system.mld
+++ b/tutos/dev/manual/how-to-implement-a-notification-system.mld
@@ -72,9 +72,9 @@ And call function [notify] on the channel (from server side)
 when you want to notify the client.
 
 To get back the [notify] functions for one user, you may want to
-{{!page-how-to-iterate-on-all-sessions-for-one-user-or-all-tabs}iterate on all client process states}.
+{{!page-"how-to-iterate-on-all-sessions-for-one-user-or-all-tabs"}iterate on all client process states}.
 To do that, create a session group for each user
-(see {{!page-how-to-register-session-data}How to register session data}).
+(see {{!page-"how-to-register-session-data"}How to register session data}).
 Here we suppose that the session group name is the user_id, as a string.
 Then iterate on all sessions from this group, and on all client processes
 for each session.

--- a/tutos/dev/manual/how-to-make-hello-world-in-ocsigen.mld
+++ b/tutos/dev/manual/how-to-make-hello-world-in-ocsigen.mld
@@ -37,9 +37,9 @@ let _ =
 {2 }
 
 - To {e understand} this code, have a look at
-{{!page-how-does-a-page-s-source-code-look}How does a page's source code look?}
+{{!page-"how-does-a-page-s-source-code-look"}How does a page's source code look?}
 - Or directly continue by compiling this code:
-{{!page-how-to-compile-my-ocsigen-pages}How to compile my Ocsigen pages?}
+{{!page-"how-to-compile-my-ocsigen-pages"}How to compile my Ocsigen pages?}
 
 
 

--- a/tutos/dev/manual/how-to-register-session-data.mld
+++ b/tutos/dev/manual/how-to-register-session-data.mld
@@ -70,5 +70,5 @@ if you restart the server.
 
 {1 Links}
 
-- {{:https://ocsigen.org/eliom/latest/server-state.html}More information on session data}
+- {{!/eliom/page-"server-state"}More information on session data}
 - module {!Eliom.Reference}

--- a/tutos/dev/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
+++ b/tutos/dev/manual/how-to-set-and-id-classes-or-other-attributes-to-html-elements.mld
@@ -36,7 +36,7 @@ The style attribute specifies an inline style for an element. The style attribut
 
 Using this attribute to stylish elements is not a good practice.
 You should rather use
-{{!page-how-to-add-css-stylesheet}an external CSS file}.
+{{!page-"how-to-add-css-stylesheet"}an external CSS file}.
 
 Its parameter is a string.
 {@ocaml[~a:[a_style "color: pink; padding: 10px;"]]}

--- a/tutos/dev/manual/how-to-use-get-parameters-or-parameters-in-the-url.mld
+++ b/tutos/dev/manual/how-to-use-get-parameters-or-parameters-in-the-url.mld
@@ -43,7 +43,7 @@ We recommend to open this module (at the beginning of your file, or locally).
 - {b Common types}: {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L121}string}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L122}int}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L123}int32}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L124}float}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L125}bool}
 - {b Some other types}: {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L126}optional values}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L158}any parameter}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L187}list}, {{:https://github.com/db0company/Ocsigen-Quick-Howto/blob/master/parameters/example.eliom#L211}your own type}.
 
-- See more information on parameters in {{:https://ocsigen.org/eliom/latest/server-params.html}Eliom manual} and API documentation of module {!Eliom.Parameter}.
+- See more information on parameters in {{!/eliom/page-"server-params"}Eliom manual} and API documentation of module {!Eliom.Parameter}.
 
 {3 Get these parameters}
 
@@ -82,7 +82,7 @@ To do that, add a parameter of type {b suffix} in {b get_params}:
 
 {2 Links}
 
-- Manual: {{:https://ocsigen.org/eliom/latest/server-params.html}Parameters}
-- Manual: {{:https://ocsigen.org/eliom/latest/server-services.html}Services}
+- Manual: {{!/eliom/page-"server-params"}Parameters}
+- Manual: {{!/eliom/page-"server-services"}Services}
 - API: {!Eliom.Parameter}
 - API: {!Eliom.Service}

--- a/tutos/dev/manual/how-to-write-forms.mld
+++ b/tutos/dev/manual/how-to-write-forms.mld
@@ -107,4 +107,4 @@ using standard tyxml constructors.
 Use module {{:https://ocsigen.org/eliom/latest/eliom.server/Eliom/Content/Html/D/Raw/index.html}Eliom.Content.Html.D.Raw}.
 
 {2 Links}
-- {{!page-how-to-add-a-select-or-other-form-element}How to write a select (or other form element)?}
+- {{!page-"how-to-add-a-select-or-other-form-element"}How to write a select (or other form element)?}

--- a/tutos/dev/manual/how-to-write-titles-and-paragraphs.mld
+++ b/tutos/dev/manual/how-to-write-titles-and-paragraphs.mld
@@ -16,7 +16,7 @@ p [txt "Some text, blah blah blah"]
 
 {b Required parameter}: list containing other elements (content: {!Html_types.flow5} elements).
 
-{b Optional parameter} for attributes "a" ({{!page-how-to-set-and-id-classes-or-other-attributes-to-html-elements}How to set and id, classes or other attributes to HTML elements?}).
+{b Optional parameter} for attributes "a" ({{!page-"how-to-set-and-id-classes-or-other-attributes-to-html-elements"}How to set and id, classes or other attributes to HTML elements?}).
 
 {2 Download full code}
 

--- a/tutos/dev/manual/html.mld
+++ b/tutos/dev/manual/html.mld
@@ -155,5 +155,5 @@ which implements functional reactive programming for OCaml.
 {1 More documentation}
 
 Have a look at {{:https://ocsigen.org/tyxml/latest/tyxml/index.html}Tyxml's manual}
-and {{:https://ocsigen.org/eliom/latest/clientserver-html.html}Eliom's manual}
+and {{!/eliom/page-"clientserver-html"}Eliom's manual}
 for more documentation about HTML manipulation in OCaml.

--- a/tutos/dev/manual/interaction.mld
+++ b/tutos/dev/manual/interaction.mld
@@ -392,7 +392,7 @@ Remember:
 {e Warning:} Even if POST parameters are not shown in the URL, they
 are sent as plain text. If you want to transmit private data (like a password),
 you must
-use HTTPS (see {{:https://ocsigen.org/ocsigenserver/latest/config.html}the Ocsigen server manual}).  {%wodoc:end%}
+use HTTPS (see {{!/ocsigenserver/page-config}the Ocsigen server manual}).  {%wodoc:end%}
 
 Now we can register a handler for the new service:
 

--- a/tutos/dev/manual/intro.mld
+++ b/tutos/dev/manual/intro.mld
@@ -35,14 +35,14 @@ at the {{:https://www.besport.com/news}Be Sport social network} (available in
 Ocsigen consists of several quite independent projects, all
 released as open source software on {{:https://github.com/ocsigen}Github}.
 The main projects are:
-- {{:https://ocsigen.org/lwt/latest/}Lwt}, a general purpose concurrent programming library for OCaml,
-- {{:https://ocsigen.org/tyxml/latest/}TyXML} for generating typed XML,
-- the {{:https://ocsigen.org/js_of_ocaml/latest/}Js_of_ocaml} compiler (from Ocaml bytecode to JavaScript),
-- {{:https://ocsigen.org/eliom/latest/}Eliom}, the multi-tier framework for client-server
+- {{!/lwt/page-index}Lwt}, a general purpose concurrent programming library for OCaml,
+- {{!/tyxml/page-index}TyXML} for generating typed XML,
+- the {{!/js_of_ocaml/page-index}Js_of_ocaml} compiler (from Ocaml bytecode to JavaScript),
+- {{!/eliom/page-index}Eliom}, the multi-tier framework for client-server
 Web and mobile apps,
-- {{:https://ocsigen.org/ocsigenserver/latest/}Ocsigen Server}, a full-featured Web server,
-- {{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen Toolkit}, a client-server widget library written for Eliom and Js_of_ocaml,
-- {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start}, an application template with
+- {{!/ocsigenserver/page-index}Ocsigen Server}, a full-featured Web server,
+- {{!/ocsigen-toolkit/page-index}Ocsigen Toolkit}, a client-server widget library written for Eliom and Js_of_ocaml,
+- {{!/ocsigen-start/page-index}Ocsigen Start}, an application template with
 many code examples, to be used as a basis for your apps, or to learn.
 
 The {{:https://ocsigen.org/install}installation is described here}.
@@ -56,7 +56,7 @@ some of the following chapters:
 - Chapter {{!page-basics}Client-server application programming guide} can be used as your training plan.
 It provides a wide overview of each main concept, with links to more detailed
 documentation.
-- If you want to start with a server-side only Web site, read {{!page-basics-server}Server-side website programming guide} instead.
+- If you want to start with a server-side only Web site, read {{!page-"basics-server"}Server-side website programming guide} instead.
 - Then, a good starting point is this
 {{!page-start}Ocsigen Start tutorial},
 if you plan to build a client-server Web (and/or mobile) app.
@@ -108,7 +108,7 @@ application.  In this chapter, you will learn how to:
 - Add an Atom feed
 - If you want to have a full application with user management
 (registration, activation emails, authentication),
-have a look at {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen-start}.
+have a look at {{!/ocsigen-start/page-index}Ocsigen-start}.
 Ocsigen-start is a library and a template for Eliom distillery that
 contains a working Eliom application with user and right
 management.

--- a/tutos/dev/manual/lwt.mld
+++ b/tutos/dev/manual/lwt.mld
@@ -172,7 +172,7 @@ let rec map_serial f l =
 
 {1 More documentation}
 
-Have a look at {{:https://ocsigen.org/lwt/latest/}Lwt's manual}
+Have a look at {{!/lwt/page-index}Lwt's manual}
 for more details about Lwt.
 You will learn how to handle exceptions (using [Lwt.fail]
 and [Lwt.catch] or [try%lwt]).

--- a/tutos/dev/manual/macaque.mld
+++ b/tutos/dev/manual/macaque.mld
@@ -14,7 +14,7 @@ time and makes difficult to generate queries at compile time.
 Macaque uses its own syntax, whereas PGOcaml uses SQL.
 Macaque supports only a small subset of Postgresql features.
 
-Warning: Macaque's syntax extension uses camlp4, which is not compatible with ppx. If you want to use macaque with Eliom's ppx, place your macaque code in an isolated file. Some details can be found in {{:https://ocsigen.org/eliom/latest/ppx-migration.html}the ppx migration guide}.
+Warning: Macaque's syntax extension uses camlp4, which is not compatible with ppx. If you want to use macaque with Eliom's ppx, place your macaque code in an isolated file. Some details can be found in {{!/eliom/page-"ppx-migration"}the ppx migration guide}.
 
 This tutorial shows how to store the login and the password
 f users in a Postgresql

--- a/tutos/dev/manual/misc.mld
+++ b/tutos/dev/manual/misc.mld
@@ -86,7 +86,7 @@ let stop_drawing { message_thread; drawing_thread } =
 
 [Lwt.cancel t] stops thread t. In this case it also closes the
   bus on which t is listening. For more informations see the
-  {{:https://ocsigen.org/lwt/latest/}Lwt programming guide} and
+  {{!/lwt/page-index}Lwt programming guide} and
   {!Eliom.Bus}.
 
 {@ocaml[

--- a/tutos/dev/manual/mobile.mld
+++ b/tutos/dev/manual/mobile.mld
@@ -8,7 +8,7 @@ fact, one single codebase can be used to produce all these
 applications simultaneously.
 
 The easiest way to get started with Ocsigen-based mobile development
-is to use {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen-start}.  Ocsigen-start is a
+is to use {{!/ocsigen-start/page-index}Ocsigen-start}.  Ocsigen-start is a
 library and skeleton for building "minimum viable product" Web
 applications with standard functionality like users, notifications,
 etc. This skeleton is immediately usable as a mobile application. You
@@ -23,7 +23,7 @@ template's [README.md].
 
 You need to follow a certain programming style for your Eliom code to
 work flawlessly inside an Ocsigen-start mobile app. This style is
-described in the {{:https://ocsigen.org/eliom/latest/clientserver-services.html}chapter on
+described in the {{!/eliom/page-"clientserver-services"}chapter on
 client services} from the Eliom manual. The idea is that you
 implement as much of your application as possible in shared sections
 ([[%%shared ...]] or [let%shared ... = ...]), and that you
@@ -34,7 +34,7 @@ inspiration.
 
 {1 Going further}
 
-- {{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen-toolkit} provides a set of user
+- {{!/ocsigen-toolkit/page-index}Ocsigen-toolkit} provides a set of user
   interface widgets that are particularly useful for mobile applications.
 
 - Danny Willems provides a comprehensive set of

--- a/tutos/dev/manual/start.mld
+++ b/tutos/dev/manual/start.mld
@@ -13,7 +13,7 @@ functionality like users and notifications in only a few minutes. This
 template can be used for learning purposes, or even as a starting
 point for your own product.
 
-The template you will use comes from {{:https://ocsigen.org/ocsigen-start/latest/}Ocsigen Start}.
+The template you will use comes from {{!/ocsigen-start/page-index}Ocsigen Start}.
 Ocsigen Start provides a complete mechanism for adding and managing
 users, including activation links and password reset. It additionally
 contains a module for displaying tips, a module for sending
@@ -77,7 +77,7 @@ you:
 - How to save session data (in {e Eliom references});
 - How to use the notification system;
 - How to create reactive pages;
-- Many examples of widgets from {{:https://ocsigen.org/ocsigen-toolkit/latest/}Ocsigen Toolkit}:
+- Many examples of widgets from {{!/ocsigen-toolkit/page-index}Ocsigen Toolkit}:
 - Carousel
 - Pages with several tabs
 - Time and date pickers

--- a/tutos/dev/manual/tutowidgets.mld
+++ b/tutos/dev/manual/tutowidgets.mld
@@ -394,7 +394,7 @@ let%server _ = Eliom.Content.Html.D.(
 An important feature missing from this tutorial is the ability
 to call server functions from the client-side program ("server functions").
 You can find a quick description of this
-in {{!page-how-to-call-a-server-side-function-from-client-side}this mini HOWTO} or
+in {{!page-"how-to-call-a-server-side-function-from-client-side"}this mini HOWTO} or
 in {{:https://ocsigen.org/eliom/latest/clientserver-communication.html#rpc}Eliom's manual}.
 
 {2 Services}
@@ -409,8 +409,8 @@ parameters), or by a session identifier (we call this kind of service
 a {e coservice}). Eliom also allows creating new (co-)services
 dynamically, for example coservices depending on previous interaction
 with a user. More information on the service identification mechanism
-in {{:https://ocsigen.org/eliom/latest/server-services.html}Eliom's manual}.
+in {{!/eliom/page-"server-services"}Eliom's manual}.
 
 {2 Sessions}
 Eliom also offers a rich session mechanism, with {e scopes}
-(see {{:https://ocsigen.org/eliom/latest/server-state.html}Eliom's manual}).
+(see {{!/eliom/page-"server-state"}Eliom's manual}).


### PR DESCRIPTION
Cross-project-links effort, tutorial edition (dev + 8.0).

## Changes (186 edits)
- **Cross-project links** to other Ocsigen projects' manual pages: hardcoded `https://ocsigen.org/<project>/latest/<page>` → odoc references `{{!/eliom/page-…}}`, `{{!/ocsigenserver/page-…}}`, etc. wodoc rewrites these to the deployed docs (the full `(hosted …)` table is now present). **Left as URLs** (correctly): anchored links (`#section`), deep API/module links, and demo links — tuto is not an opam package so those cannot become verified references.
- **Quoting fix**: odoc cannot parse a **hyphenated** page name in a reference (`{{!page-basics-server}}` → "Unknown reference qualifier"); it needs `{{!page-"basics-server"}}`. Quoted all hyphenated page names — this also repairs **pre-existing broken** intra-tutorial links (e.g. `page-how-to-…`, `page-basics-server`) that rendered as plain text.

## Verification
All converted pages compile with `odoc compile` with no reference-qualifier or markup errors (the only remaining warnings are pre-existing `{{img|alt}}` wiki-image artifacts in `start.mld`, unrelated). No unquoted hyphenated page reference remains.