### PR TITLE
doc: convert leftover wikicreole definition lists to bullet lists

### DIFF
--- a/tutos/8.0/manual/basics-server.mld
+++ b/tutos/8.0/manual/basics-server.mld
@@ -811,34 +811,21 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{!/ocsigenserver/page-staticmod}Staticmod}
-:    to serve static files.
-;{{!/eliom/page-index}Eliom}
-:    to create reliable client/server Web applications
+- {{!/ocsigenserver/page-staticmod}Staticmod}: to serve static files.
+- {{!/eliom/page-index}Eliom}: to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
-:    allows for more options in the configuration file.
-;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
-:    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{!/ocsigenserver/page-authbasic}Authbasic}
-:    restricts access to the sites from the config file using Basic HTTP Authentication.
-;CGImod
-:    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{!/ocsigenserver/page-deflatemod}Deflatemod}
-:    used to compress data before sending it to the client.
-;{{!/ocsigenserver/page-redirectmod}Redirectmod}
-:    sets redirections towards other Web sites from the configuration file.
-;{{!/ocsigenserver/page-revproxy}Revproxy}
-:    a reverse proxy for Ocsigen Server.
+- {{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}: allows for more options in the configuration file.
+- {{!/ocsigenserver/page-accesscontrol}Accesscontrol}: restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
+- {{!/ocsigenserver/page-authbasic}Authbasic}: restricts access to the sites from the config file using Basic HTTP Authentication.
+- CGImod: serves CGI scripts. It may also be used to serve PHP through CGI.
+- {{!/ocsigenserver/page-deflatemod}Deflatemod}: used to compress data before sending it to the client.
+- {{!/ocsigenserver/page-redirectmod}Redirectmod}: sets redirections towards other Web sites from the configuration file.
+- {{!/ocsigenserver/page-revproxy}Revproxy}: a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{!/ocsigenserver/page-rewritemod}Rewritemod}
-:    changes incoming requests before sending them to other extensions.
-;{{!/ocsigenserver/page-outputfilter}Outputfilter}
-:    rewrites some parts of the output before sending it to the client.
-;{{!/ocsigenserver/page-userconf}Userconf}
-:    allows users to have their own configuration files.
-;Comet
-:    facilitates server to client communications.
+- {{!/ocsigenserver/page-rewritemod}Rewritemod}: changes incoming requests before sending them to other extensions.
+- {{!/ocsigenserver/page-outputfilter}Outputfilter}: rewrites some parts of the output before sending it to the client.
+- {{!/ocsigenserver/page-userconf}Userconf}: allows users to have their own configuration files.
+- Comet: facilitates server to client communications.
 
 Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.

--- a/tutos/8.0/manual/basics.mld
+++ b/tutos/8.0/manual/basics.mld
@@ -1311,34 +1311,21 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{!/ocsigenserver/page-staticmod}Staticmod}
-:    to serve static files.
-;{{!/eliom/page-index}Eliom}
-:    to create reliable client/server Web applications
+- {{!/ocsigenserver/page-staticmod}Staticmod}: to serve static files.
+- {{!/eliom/page-index}Eliom}: to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
-:    allows for more options in the configuration file.
-;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
-:    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{!/ocsigenserver/page-authbasic}Authbasic}
-:    restricts access to the sites from the config file using Basic HTTP Authentication.
-;CGImod
-:    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{!/ocsigenserver/page-deflatemod}Deflatemod}
-:    used to compress data before sending it to the client.
-;{{!/ocsigenserver/page-redirectmod}Redirectmod}
-:    sets redirections towards other Web sites from the configuration file.
-;{{!/ocsigenserver/page-revproxy}Revproxy}
-:    a reverse proxy for Ocsigen Server.
+- {{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}: allows for more options in the configuration file.
+- {{!/ocsigenserver/page-accesscontrol}Accesscontrol}: restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
+- {{!/ocsigenserver/page-authbasic}Authbasic}: restricts access to the sites from the config file using Basic HTTP Authentication.
+- CGImod: serves CGI scripts. It may also be used to serve PHP through CGI.
+- {{!/ocsigenserver/page-deflatemod}Deflatemod}: used to compress data before sending it to the client.
+- {{!/ocsigenserver/page-redirectmod}Redirectmod}: sets redirections towards other Web sites from the configuration file.
+- {{!/ocsigenserver/page-revproxy}Revproxy}: a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{!/ocsigenserver/page-rewritemod}Rewritemod}
-:    changes incoming requests before sending them to other extensions.
-;{{!/ocsigenserver/page-outputfilter}Outputfilter}
-:    rewrites some parts of the output before sending it to the client.
-;{{!/ocsigenserver/page-userconf}Userconf}
-:    allows users to have their own configuration files.
-;Comet
-:    facilitates server to client communications.
+- {{!/ocsigenserver/page-rewritemod}Rewritemod}: changes incoming requests before sending them to other extensions.
+- {{!/ocsigenserver/page-outputfilter}Outputfilter}: rewrites some parts of the output before sending it to the client.
+- {{!/ocsigenserver/page-userconf}Userconf}: allows users to have their own configuration files.
+- Comet: facilitates server to client communications.
 
 Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.

--- a/tutos/8.0/manual/how-to-detect-channel-disconnection.mld
+++ b/tutos/8.0/manual/how-to-detect-channel-disconnection.mld
@@ -28,12 +28,9 @@ information through an exception when you try to read from the
 Lwt_stream. The different exceptions you have to handle depending on the
 case are:
 
-;[Eliom_comet.Channel_full]
-:For global channel. Those are never closed on server side and are not attached to a particular session. The server maintains a limited buffer of previous values to avoid memory leak. If a client reconnects to the network and too many messages have been sent to the channel since its last update, it will receive that exception.
-;[Eliom_comet.Process_closed] (Eliom < 5)
-:For a channel associated to a client process. If the process is explicitly closed on the server, the server is rebooted, it timed out, ...
-;[Eliom_comet.Channel_closed]
-:The channel was not maintained alive on the server (garbage collected).
+- [Eliom_comet.Channel_full]: For global channel. Those are never closed on server side and are not attached to a particular session. The server maintains a limited buffer of previous values to avoid memory leak. If a client reconnects to the network and too many messages have been sent to the channel since its last update, it will receive that exception.
+- [Eliom_comet.Process_closed] (Eliom < 5): For a channel associated to a client process. If the process is explicitly closed on the server, the server is rebooted, it timed out, ...
+- [Eliom_comet.Channel_closed]: The channel was not maintained alive on the server (garbage collected).
 
 Usually it is just simpler to not distinguish and just catch all those
 exceptions and consider their meaning to be 'disconnected'.

--- a/tutos/dev/manual/basics-server.mld
+++ b/tutos/dev/manual/basics-server.mld
@@ -811,34 +811,21 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{!/ocsigenserver/page-staticmod}Staticmod}
-:    to serve static files.
-;{{!/eliom/page-index}Eliom}
-:    to create reliable client/server Web applications
+- {{!/ocsigenserver/page-staticmod}Staticmod}: to serve static files.
+- {{!/eliom/page-index}Eliom}: to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
-:    allows for more options in the configuration file.
-;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
-:    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{!/ocsigenserver/page-authbasic}Authbasic}
-:    restricts access to the sites from the config file using Basic HTTP Authentication.
-;CGImod
-:    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{!/ocsigenserver/page-deflatemod}Deflatemod}
-:    used to compress data before sending it to the client.
-;{{!/ocsigenserver/page-redirectmod}Redirectmod}
-:    sets redirections towards other Web sites from the configuration file.
-;{{!/ocsigenserver/page-revproxy}Revproxy}
-:    a reverse proxy for Ocsigen Server.
+- {{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}: allows for more options in the configuration file.
+- {{!/ocsigenserver/page-accesscontrol}Accesscontrol}: restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
+- {{!/ocsigenserver/page-authbasic}Authbasic}: restricts access to the sites from the config file using Basic HTTP Authentication.
+- CGImod: serves CGI scripts. It may also be used to serve PHP through CGI.
+- {{!/ocsigenserver/page-deflatemod}Deflatemod}: used to compress data before sending it to the client.
+- {{!/ocsigenserver/page-redirectmod}Redirectmod}: sets redirections towards other Web sites from the configuration file.
+- {{!/ocsigenserver/page-revproxy}Revproxy}: a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{!/ocsigenserver/page-rewritemod}Rewritemod}
-:    changes incoming requests before sending them to other extensions.
-;{{!/ocsigenserver/page-outputfilter}Outputfilter}
-:    rewrites some parts of the output before sending it to the client.
-;{{!/ocsigenserver/page-userconf}Userconf}
-:    allows users to have their own configuration files.
-;Comet
-:    facilitates server to client communications.
+- {{!/ocsigenserver/page-rewritemod}Rewritemod}: changes incoming requests before sending them to other extensions.
+- {{!/ocsigenserver/page-outputfilter}Outputfilter}: rewrites some parts of the output before sending it to the client.
+- {{!/ocsigenserver/page-userconf}Userconf}: allows users to have their own configuration files.
+- Comet: facilitates server to client communications.
 
 Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.

--- a/tutos/dev/manual/basics.mld
+++ b/tutos/dev/manual/basics.mld
@@ -1311,34 +1311,21 @@ It is now based on {{:https://github.com/mirage/ocaml-cohttp}Cohttp}.
 It has a powerful
 extension mechanism that makes it easy to plug your own OCaml modules
 for generating pages. Many extensions are already written:
-;{{!/ocsigenserver/page-staticmod}Staticmod}
-:    to serve static files.
-;{{!/eliom/page-index}Eliom}
-:    to create reliable client/server Web applications
+- {{!/ocsigenserver/page-staticmod}Staticmod}: to serve static files.
+- {{!/eliom/page-index}Eliom}: to create reliable client/server Web applications
      or Web sites in OCaml using advanced high level concepts.
-;{{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}
-:    allows for more options in the configuration file.
-;{{!/ocsigenserver/page-accesscontrol}Accesscontrol}
-:    restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
-;{{!/ocsigenserver/page-authbasic}Authbasic}
-:    restricts access to the sites from the config file using Basic HTTP Authentication.
-;CGImod
-:    serves CGI scripts. It may also be used to serve PHP through CGI.
-;{{!/ocsigenserver/page-deflatemod}Deflatemod}
-:    used to compress data before sending it to the client.
-;{{!/ocsigenserver/page-redirectmod}Redirectmod}
-:    sets redirections towards other Web sites from the configuration file.
-;{{!/ocsigenserver/page-revproxy}Revproxy}
-:    a reverse proxy for Ocsigen Server.
+- {{!/ocsigenserver/page-extendconfiguration}Extendconfiguration}: allows for more options in the configuration file.
+- {{!/ocsigenserver/page-accesscontrol}Accesscontrol}: restricts access to the sites from the config file (to requests coming from a subnet, containing some headers, etc.).
+- {{!/ocsigenserver/page-authbasic}Authbasic}: restricts access to the sites from the config file using Basic HTTP Authentication.
+- CGImod: serves CGI scripts. It may also be used to serve PHP through CGI.
+- {{!/ocsigenserver/page-deflatemod}Deflatemod}: used to compress data before sending it to the client.
+- {{!/ocsigenserver/page-redirectmod}Redirectmod}: sets redirections towards other Web sites from the configuration file.
+- {{!/ocsigenserver/page-revproxy}Revproxy}: a reverse proxy for Ocsigen Server.
       It allows to ask another server to handle the request.
-;{{!/ocsigenserver/page-rewritemod}Rewritemod}
-:    changes incoming requests before sending them to other extensions.
-;{{!/ocsigenserver/page-outputfilter}Outputfilter}
-:    rewrites some parts of the output before sending it to the client.
-;{{!/ocsigenserver/page-userconf}Userconf}
-:    allows users to have their own configuration files.
-;Comet
-:    facilitates server to client communications.
+- {{!/ocsigenserver/page-rewritemod}Rewritemod}: changes incoming requests before sending them to other extensions.
+- {{!/ocsigenserver/page-outputfilter}Outputfilter}: rewrites some parts of the output before sending it to the client.
+- {{!/ocsigenserver/page-userconf}Userconf}: allows users to have their own configuration files.
+- Comet: facilitates server to client communications.
 
 Ocsigen Server has a {{!/ocsigenserver/page-config}sophisticated configuration} file mechanism allowing
 complex configurations of sites.

--- a/tutos/dev/manual/how-to-detect-channel-disconnection.mld
+++ b/tutos/dev/manual/how-to-detect-channel-disconnection.mld
@@ -28,12 +28,9 @@ information through an exception when you try to read from the
 Lwt_stream. The different exceptions you have to handle depending on the
 case are:
 
-;[Eliom.Comet.Channel_full]
-:For global channel. Those are never closed on server side and are not attached to a particular session. The server maintains a limited buffer of previous values to avoid memory leak. If a client reconnects to the network and too many messages have been sent to the channel since its last update, it will receive that exception.
-;[Eliom.Comet.Process_closed] (Eliom < 5)
-:For a channel associated to a client process. If the process is explicitly closed on the server, the server is rebooted, it timed out, ...
-;[Eliom.Comet.Channel_closed]
-:The channel was not maintained alive on the server (garbage collected).
+- [Eliom.Comet.Channel_full]: For global channel. Those are never closed on server side and are not attached to a particular session. The server maintains a limited buffer of previous values to avoid memory leak. If a client reconnects to the network and too many messages have been sent to the channel since its last update, it will receive that exception.
+- [Eliom.Comet.Process_closed] (Eliom < 5): For a channel associated to a client process. If the process is explicitly closed on the server, the server is rebooted, it timed out, ...
+- [Eliom.Comet.Channel_closed]: The channel was not maintained alive on the server (garbage collected).
 
 Usually it is just simpler to not distinguish and just catch all those
 exceptions and consider their meaning to be 'disconnected'.


### PR DESCRIPTION
The extension lists (basics, basics-server) and the channel-exception lists (how-to-detect-channel-disconnection), in both the `8.0` and `dev` tutorials, still used wikicreole definition-list syntax (`;term` / `:definition`), which odoc renders literally.

Convert each pair to a proper odoc bullet item (`- term: definition`). `migration.mld` is intentionally left untouched: its `;` lines are Lisp comments inside a `{@lisp[...]}` code block, not definition lists. Doc-only change.