### PR TITLE
Point Js_of_ocaml binding links to the JavaScript interop page

### DIFF
--- a/tutos/8.0/manual/application.mld
+++ b/tutos/8.0/manual/application.mld
@@ -345,7 +345,7 @@ some element produced by the service.
 
 The client-side parts of the program are compiled to JavaScript by
 [js_of_ocaml]. (Technically, [js_of_ocaml] compiles OCaml
-bytecode to JavaScript.)  It is easy {{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/bindings.html}to bind JavaScript libraries} so that OCaml
+bytecode to JavaScript.)  It is easy {{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/javascript-interop.html}to bind JavaScript libraries} so that OCaml
 programs can call JavaScript functions. In the example, we are using
 the {!Js_of_ocaml.Dom_html} module, which
 is a binding that allows the manipulation of an HTML page.

--- a/tutos/8.0/manual/how-to-add-a-javascript-script.mld
+++ b/tutos/8.0/manual/how-to-add-a-javascript-script.mld
@@ -26,5 +26,5 @@ Or you can use:
 {2 Call an external function}
 
 Have a look at
-{{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/bindings.html}this page of Js_of_ocaml's manual}
+{{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/javascript-interop.html}this page of Js_of_ocaml's manual}
 to understand how to call JS function from your OCaml program.

--- a/tutos/dev/manual/application.mld
+++ b/tutos/dev/manual/application.mld
@@ -345,7 +345,7 @@ some element produced by the service.
 
 The client-side parts of the program are compiled to JavaScript by
 [js_of_ocaml]. (Technically, [js_of_ocaml] compiles OCaml
-bytecode to JavaScript.)  It is easy {{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/bindings.html}to bind JavaScript libraries} so that OCaml
+bytecode to JavaScript.)  It is easy {{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/javascript-interop.html}to bind JavaScript libraries} so that OCaml
 programs can call JavaScript functions. In the example, we are using
 the {!Js_of_ocaml.Dom_html} module, which
 is a binding that allows the manipulation of an HTML page.

--- a/tutos/dev/manual/how-to-add-a-javascript-script.mld
+++ b/tutos/dev/manual/how-to-add-a-javascript-script.mld
@@ -26,5 +26,5 @@ Or you can use:
 {2 Call an external function}
 
 Have a look at
-{{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/bindings.html}this page of Js_of_ocaml's manual}
+{{:https://ocsigen.org/js_of_ocaml/latest/js_of_ocaml/javascript-interop.html}this page of Js_of_ocaml's manual}
 to understand how to call JS function from your OCaml program.


### PR DESCRIPTION
The "Binding a JS library" page of the Js_of_ocaml manual was merged into "JavaScript interop"; link to the real page rather than to the redirect stub, which is being removed.